### PR TITLE
override channel settings

### DIFF
--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -37,6 +37,7 @@ fraction: 1.0 # (float) dataset fraction to train on (default is 1.0, all images
 profile: False # (bool) profile ONNX and TensorRT speeds during training for loggers
 freeze: # (int | list, optional) freeze first n layers, or freeze list of layer indices during training
 multi_scale: False # (bool) Whether to use multiscale during training
+channels: 3 # (int) number of input image channels (1 for grayscale, 3 for RGB, N for multispectral)
 # Segmentation
 overlap_mask: True # (bool) merge object masks into a single image mask during training (segment train only)
 mask_ratio: 4 # (int) mask downsample ratio (segment train only)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -613,6 +613,13 @@ class BaseTrainer:
             LOGGER.info("Overriding class names with single class.")
             data["names"] = {0: "item"}
             data["nc"] = 1
+        
+        # Override channels if specified in args
+        if hasattr(self.args, 'channels') and self.args.channels is not None:
+            if 'channels' in data and data['channels'] != self.args.channels:
+                LOGGER.info(f"Overriding dataset channels from {data.get('channels', 3)} to {self.args.channels}")
+            data['channels'] = self.args.channels
+        
         return data
 
     def setup_model(self):


### PR DESCRIPTION
Ultralytics newest version have support gray scale channel, we can set it through channels config automatically. I have ran multiple test and add debug message to confirm the input image channel is 1 when we set the channels to 1. 

<img width="645" height="32" alt="image" src="https://github.com/user-attachments/assets/081b7c26-6843-4a18-95fb-3a67f9776949" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying the number of input image channels (e.g., grayscale, RGB, multispectral) in the configuration settings.
  * Training now allows overriding the dataset's input channels based on the new configuration parameter.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->