### PR TITLE
Feat/sklrdev 1769 improve kp

### DIFF
--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -37,7 +37,7 @@ fraction: 1.0 # (float) dataset fraction to train on (default is 1.0, all images
 profile: False # (bool) profile ONNX and TensorRT speeds during training for loggers
 freeze: # (int | list, optional) freeze first n layers, or freeze list of layer indices during training
 multi_scale: False # (bool) Whether to use multiscale during training
-fitness_weight: [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.9, 0.1] # (list[float]) fitness weights for [P, R, mAP@0.5, mAP@0.5:0.95] for detection/OBB/classify tasks, or [box_P, box_R, box_mAP@0.5, box_mAP@0.5:0.95, pose_P, pose_R, pose_mAP@0.5, pose_mAP@0.5:0.95] for pose/segment tasks (8 values). Can be overridden for custom optimization targets.
+fitness_weight: [0.0, 0.9, 0.0, 0.1, 0.0, 0.2, 0.0, 0.8] # (list[float]) fitness weights for [P, R, mAP@0.5, mAP@0.5:0.95] for detection/OBB/classify tasks, or [box_P, box_R, box_mAP@0.5, box_mAP@0.5:0.95, pose_P, pose_R, pose_mAP@0.5, pose_mAP@0.5:0.95] for pose/segment tasks (8 values). Can be overridden for custom optimization targets.
 channels: 3 # (int) number of input image channels (1 for grayscale, 3 for RGB, N for multispectral)
 # Segmentation
 overlap_mask: True # (bool) merge object masks into a single image mask during training (segment train only)
@@ -100,8 +100,8 @@ warmup_bias_lr: 0.1 # (float) warmup initial bias lr
 box: 7.5 # (float) box loss gain
 cls: 0.5 # (float) cls loss gain (scale with pixels)
 dfl: 1.5 # (float) dfl loss gain
-pose: 12.0 # (float) pose loss gain
-kobj: 1.0 # (float) keypoint obj loss gain
+pose: 20.0 # (float) pose loss gain
+kobj: 5.0 # (float) keypoint obj loss gain
 nbs: 64 # (int) nominal batch size
 hsv_h: 0.015 # (float) image HSV-Hue augmentation (fraction)
 hsv_s: 0.7 # (float) image HSV-Saturation augmentation (fraction)

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -101,7 +101,7 @@ box: 7.5 # (float) box loss gain
 cls: 0.5 # (float) cls loss gain (scale with pixels)
 dfl: 1.5 # (float) dfl loss gain
 pose: 20.0 # (float) pose loss gain
-kobj: 5.0 # (float) keypoint obj loss gain
+kobj: 4.0 # (float) keypoint obj loss gain
 nbs: 64 # (int) nominal batch size
 hsv_h: 0.015 # (float) image HSV-Hue augmentation (fraction)
 hsv_s: 0.7 # (float) image HSV-Saturation augmentation (fraction)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -597,7 +597,7 @@ class BaseTrainer:
         # Get fitness weights from args if available
         fitness_weight = getattr(self.args, 'fitness_weight', None)
         if fitness_weight is None:
-            fitness_weight = [0.0, 0.0, 0.1, 0.9]  # default
+            fitness_weight = [0.0, 0.9, 0.1, 0.0]  # default for SkillReal dataset
 
         # Determine task type and metric names
         task = getattr(self.args, 'task', 'detect')

--- a/ultralytics/models/yolo/detect/val.py
+++ b/ultralytics/models/yolo/detect/val.py
@@ -101,8 +101,8 @@ class DetectionValidator(BaseValidator):
         # Update metrics with fitness_weight from config if needed
         # For DetectionValidator, update self.metrics.box.fitness_weight directly
         # For PoseValidator/SegmentValidator, the weights are already split in __init__, so skip this
-        if self.args.task == 'detect' and (not hasattr(self.metrics.box, 'fitness_weight') or self.metrics.box.fitness_weight == [0.0, 0.0, 0.1, 0.9]):
-            fitness_weight = getattr(self.args, 'fitness_weight', [0.0, 0.0, 0.1, 0.9])
+        if self.args.task == 'detect' and (not hasattr(self.metrics.box, 'fitness_weight') or self.metrics.box.fitness_weight == [0.0, 0.9, 0.1, 0.0]):
+            fitness_weight = getattr(self.args, 'fitness_weight', [0.0, 0.9, 0.1, 0.0]) # default for SkillReal dataset
             self.metrics.box.fitness_weight = fitness_weight
         self.confusion_matrix = ConfusionMatrix(names=list(model.names.values()))
 

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -12,9 +12,9 @@ import torch
 from ultralytics.utils import LOGGER, DataExportMixin, SimpleClass, TryExcept, checks, plt_settings
 
 OKS_SIGMA = (
-    np.array([0.26, 0.25, 0.25, 0.35, 0.35, 0.79, 0.79, 0.72, 0.72, 0.62, 0.62, 1.07, 1.07, 0.87, 0.87, 0.89, 0.89])
+    np.array([0.1, 0.1, 0.1, 0.1, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2, 0.2])
     / 10.0
-)
+) # default for SkillReal dataset
 
 
 def bbox_ioa(box1: np.ndarray, box2: np.ndarray, iou: bool = False, eps: float = 1e-7) -> np.ndarray:
@@ -804,7 +804,7 @@ class Metric(SimpleClass):
         self.all_ap = []  # (nc, 10)
         self.ap_class_index = []  # (nc, )
         self.nc = 0
-        self.fitness_weight = fitness_weight or [0.0, 0.0, 0.1, 0.9]  # default weights
+        self.fitness_weight = fitness_weight or [0.0, 0.9, 0.1, 0.0]  # default weights for SkillReal dataset
 
     @property
     def ap50(self) -> Union[np.ndarray, List]:


### PR DESCRIPTION
Changing default values for better keypoint recall and accuracy.

The OKS sigmas control how tolerant the pose evaluator is to keypoint localization error.
By replacing the COCO-specific sigmas with values tailored to our dataset, OKS becomes a more accurate measure of true keypoint quality, leading to more meaningful TP/FP decisions and more reliable pose accuracy metrics.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added extensive augmentation and hyperparameter options (mask_ratio, dropout for classification, HSV/geometry transforms, mosaic/mix strategies, auto-augment, erasing, etc.).

* **Improvements**
  * Adjusted default fitness weighting and increased pose/keypoint loss gains for evaluation and training balance.
  * Refined keypoint similarity parameters for dataset-optimized accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->