### PR TITLE
Classification loss modifier

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,7 @@ dmypy.json
 
 # datasets and projects (ignore /datasets dir at root only to allow for docs/en/datasets dir)
 /datasets
+/data
 runs/
 wandb/
 .DS_Store

--- a/scripts/debug_gpu_partition.py
+++ b/scripts/debug_gpu_partition.py
@@ -42,7 +42,7 @@ def main():
 
     for rank in range(num_gpus):
         start_idx, end_idx = get_rank_indices(total_images, per_gpu_batch, num_gpus, rank)
-        print(f"GPU {rank} (rank {rank}): samples {start_idx} to {end_idx-1} ({end_idx - start_idx} samples)")
+        print(f"GPU {rank} (rank {rank}): samples {start_idx} to {end_idx - 1} ({end_idx - start_idx} samples)")
 
     print()
     print("=" * 60)
@@ -52,7 +52,7 @@ def main():
 
     # Show the specific range for GPU 3
     start_idx, end_idx = get_rank_indices(total_images, per_gpu_batch, num_gpus, 3)
-    print(f"Check images at indices {start_idx} to {end_idx-1} for corruption or issues.")
+    print(f"Check images at indices {start_idx} to {end_idx - 1} for corruption or issues.")
     print()
 
     # Also show first few indices that GPU 3 will try to load

--- a/scripts/find_bad_sample.py
+++ b/scripts/find_bad_sample.py
@@ -1,22 +1,23 @@
 """Script to find problematic samples in GPU 3's partition."""
 
-import sys
 import signal
 from pathlib import Path
+
 
 # Timeout handler
 class TimeoutError(Exception):
     pass
 
+
 def timeout_handler(signum, frame):
     raise TimeoutError("Sample loading timed out!")
+
 
 # Set up signal handler for timeout
 signal.signal(signal.SIGALRM, timeout_handler)
 
 
 def test_samples():
-    from ultralytics import YOLO
     from ultralytics.data import YOLODataset
     from ultralytics.data.utils import check_det_dataset
 
@@ -57,7 +58,7 @@ def test_samples():
     start_idx = 4320
     end_idx = min(5737, len(dataset))
 
-    print(f"Testing samples {start_idx} to {end_idx-1} (GPU 3's partition)")
+    print(f"Testing samples {start_idx} to {end_idx - 1} (GPU 3's partition)")
     print("=" * 60)
 
     bad_samples = []
@@ -68,7 +69,7 @@ def test_samples():
             signal.alarm(10)
 
             # Try to load the sample
-            sample = dataset[idx]
+            dataset[idx]
 
             # Cancel alarm
             signal.alarm(0)

--- a/scripts/test_classification_loss.py
+++ b/scripts/test_classification_loss.py
@@ -17,6 +17,7 @@ Trains 9 models (50 epochs each) with aggressive Reject-boosting to show the eff
 Usage:
     python scripts/test_classification_loss.py
 """
+
 from __future__ import annotations
 
 import random
@@ -169,14 +170,10 @@ def main():
     )
 
     # 4. Focal loss γ=2.0
-    results.append(
-        train_and_evaluate("focal_g2", data_dir, cls_loss="focal", focal_gamma=2.0, epochs=epochs)
-    )
+    results.append(train_and_evaluate("focal_g2", data_dir, cls_loss="focal", focal_gamma=2.0, epochs=epochs))
 
     # 5. Focal loss γ=5.0 — stronger hard-example focus
-    results.append(
-        train_and_evaluate("focal_g5", data_dir, cls_loss="focal", focal_gamma=5.0, epochs=epochs)
-    )
+    results.append(train_and_evaluate("focal_g5", data_dir, cls_loss="focal", focal_gamma=5.0, epochs=epochs))
 
     # 6. Focal loss γ=2 + Reject ×10
     results.append(
@@ -192,9 +189,7 @@ def main():
 
     # 7. Class-balanced focal γ=2 (auto frequency weights)
     results.append(
-        train_and_evaluate(
-            "cb_focal_g2", data_dir, cls_loss="cb_focal", focal_gamma=2.0, cb_beta=0.999, epochs=epochs
-        )
+        train_and_evaluate("cb_focal_g2", data_dir, cls_loss="cb_focal", focal_gamma=2.0, cb_beta=0.999, epochs=epochs)
     )
 
     # 8. Class-balanced focal γ=2 + extra Reject ×10
@@ -211,34 +206,32 @@ def main():
     )
 
     # 9. CE + label smoothing
-    results.append(
-        train_and_evaluate(
-            "ce_label_smooth", data_dir, cls_loss="ce", label_smoothing=0.1, epochs=epochs
-        )
-    )
+    results.append(train_and_evaluate("ce_label_smooth", data_dir, cls_loss="ce", label_smoothing=0.1, epochs=epochs))
 
     # 10. ArcFace — default margin=0.5, scale=30
     results.append(
         train_and_evaluate(
-            "arcface_m05_s30", data_dir, cls_loss="arcface",
-            arcface_margin=0.5, arcface_scale=30.0, epochs=epochs
+            "arcface_m05_s30", data_dir, cls_loss="arcface", arcface_margin=0.5, arcface_scale=30.0, epochs=epochs
         )
     )
 
     # 11. ArcFace — larger margin for stricter separation
     results.append(
         train_and_evaluate(
-            "arcface_m10_s30", data_dir, cls_loss="arcface",
-            arcface_margin=1.0, arcface_scale=30.0, epochs=epochs
+            "arcface_m10_s30", data_dir, cls_loss="arcface", arcface_margin=1.0, arcface_scale=30.0, epochs=epochs
         )
     )
 
     # 12. ArcFace + class_weights boosting Reject
     results.append(
         train_and_evaluate(
-            "arcface_m05_w10", data_dir, cls_loss="arcface",
-            arcface_margin=0.5, arcface_scale=30.0,
-            class_weights={rare_class: 10.0}, epochs=epochs
+            "arcface_m05_w10",
+            data_dir,
+            cls_loss="arcface",
+            arcface_margin=0.5,
+            arcface_scale=30.0,
+            class_weights={rare_class: 10.0},
+            epochs=epochs,
         )
     )
 

--- a/scripts/test_classification_loss.py
+++ b/scripts/test_classification_loss.py
@@ -1,0 +1,232 @@
+"""Demo: train YOLO classification with different loss types and compare results.
+
+Uses a local dataset at data/classification/ with class subfolders (e.g. Approve/, Reject/).
+Auto-splits into train/val (80/20) if no train/ subfolder exists.
+
+Trains 9 models (50 epochs each) with aggressive Reject-boosting to show the effect of:
+  1. ce              – standard cross-entropy (baseline)
+  2. ce + w10        – weighted CE (Reject ×10)
+  3. ce + w20        – weighted CE (Reject ×20)
+  4. focal γ=2       – focal loss
+  5. focal γ=5       – focal loss with stronger hard-example focus
+  6. focal γ=2 + w10 – focal loss + heavy Reject weight
+  7. cb_focal γ=2    – class-balanced focal (auto frequency weights)
+  8. cb_focal + w10  – class-balanced focal + extra Reject weight
+  9. ce + smoothing  – cross-entropy with label smoothing
+
+Usage:
+    python scripts/test_classification_loss.py
+"""
+from __future__ import annotations
+
+import random
+import shutil
+import sys
+from pathlib import Path
+
+# Ensure local ultralytics is used
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from ultralytics import YOLO
+
+# ── Paths ─────────────────────────────────────────────────────────────────────
+RAW_DIR = Path(__file__).resolve().parent.parent / "data" / "classification"
+SPLIT_DIR = Path(__file__).resolve().parent.parent / "data" / "classification_split"
+
+
+def prepare_train_val(raw_dir: Path, split_dir: Path, val_ratio: float = 0.2, seed: int = 42):
+    """Split a flat class-folder dataset into train/val structure.
+
+    If split_dir already exists it is reused (no re-split).
+    """
+    if (split_dir / "train").exists() and (split_dir / "val").exists():
+        print(f"[INFO] Using existing split at {split_dir}")
+        return
+
+    print(f"[INFO] Splitting {raw_dir} -> {split_dir}  (val_ratio={val_ratio})")
+    random.seed(seed)
+    split_dir.mkdir(parents=True, exist_ok=True)
+
+    classes = sorted(d.name for d in raw_dir.iterdir() if d.is_dir() and d.name not in ("train", "val", "test"))
+    for cls_name in classes:
+        cls_dir = raw_dir / cls_name
+        images = sorted(f for f in cls_dir.iterdir() if f.is_file())
+        random.shuffle(images)
+        n_val = max(1, int(len(images) * val_ratio))
+        val_imgs = images[:n_val]
+        train_imgs = images[n_val:]
+
+        for img in train_imgs:
+            dst = split_dir / "train" / cls_name / img.name
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(img, dst)
+        for img in val_imgs:
+            dst = split_dir / "val" / cls_name / img.name
+            dst.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(img, dst)
+
+        print(f"  {cls_name}: {len(train_imgs)} train, {len(val_imgs)} val")
+
+
+def train_and_evaluate(
+    run_name: str,
+    data_dir: str,
+    cls_loss: str = "ce",
+    class_weights: dict | None = None,
+    label_smoothing: float = 0.0,
+    focal_gamma: float = 2.0,
+    cb_beta: float = 0.9999,
+    epochs: int = 50,
+) -> dict:
+    """Train a classification model and return metrics."""
+    print(f"\n{'=' * 70}")
+    print(f"  Training: {run_name}")
+    print(f"  cls_loss={cls_loss}, class_weights={class_weights}")
+    print(f"  label_smoothing={label_smoothing}, focal_gamma={focal_gamma}, cb_beta={cb_beta}")
+    print(f"  epochs={epochs}")
+    print(f"{'=' * 70}\n")
+
+    model = YOLO("yolo11n-cls.pt")
+
+    kwargs = dict(
+        data=data_dir,
+        epochs=epochs,
+        imgsz=64,
+        batch=32,
+        project="runs/cls_loss_demo",
+        name=run_name,
+        exist_ok=True,
+        verbose=False,
+        cls_loss=cls_loss,
+        label_smoothing=label_smoothing,
+        focal_gamma=focal_gamma,
+        cb_beta=cb_beta,
+    )
+    if class_weights is not None:
+        kwargs["class_weights"] = class_weights
+
+    model.train(**kwargs)
+
+    metrics = model.val(data=data_dir, imgsz=64, batch=32, verbose=False)
+    top1 = metrics.top1
+    top5 = metrics.top5
+
+    return {"run_name": run_name, "top1": top1, "top5": top5}
+
+
+def main():
+    # ── Validate & split ──
+    if not RAW_DIR.exists():
+        print(f"ERROR: Dataset not found at {RAW_DIR}")
+        sys.exit(1)
+
+    prepare_train_val(RAW_DIR, SPLIT_DIR, val_ratio=0.2)
+    data_dir = str(SPLIT_DIR)
+
+    # Discover classes
+    classes = sorted(d.name for d in (SPLIT_DIR / "train").iterdir() if d.is_dir())
+    counts = {c: len(list((SPLIT_DIR / "train" / c).iterdir())) for c in classes}
+    print(f"\nDataset: {data_dir}")
+    print(f"Classes: {classes}")
+    print(f"Train counts: {counts}")
+
+    # Find the rare class to boost — Reject is far more important
+    rare_class = min(counts, key=counts.get)
+    print(f"Critical class (must not miss): '{rare_class}' ({counts[rare_class]} samples)")
+
+    epochs = 50
+    results = []
+
+    # 1. Baseline CE
+    results.append(train_and_evaluate("baseline_ce", data_dir, cls_loss="ce", epochs=epochs))
+
+    # 2. Weighted CE — Reject ×10
+    results.append(
+        train_and_evaluate(
+            "weighted_ce_10x",
+            data_dir,
+            cls_loss="ce",
+            class_weights={rare_class: 10.0},
+            epochs=epochs,
+        )
+    )
+
+    # 3. Weighted CE — Reject ×20 (extreme)
+    results.append(
+        train_and_evaluate(
+            "weighted_ce_20x",
+            data_dir,
+            cls_loss="ce",
+            class_weights={rare_class: 20.0},
+            epochs=epochs,
+        )
+    )
+
+    # 4. Focal loss γ=2.0
+    results.append(
+        train_and_evaluate("focal_g2", data_dir, cls_loss="focal", focal_gamma=2.0, epochs=epochs)
+    )
+
+    # 5. Focal loss γ=5.0 — stronger hard-example focus
+    results.append(
+        train_and_evaluate("focal_g5", data_dir, cls_loss="focal", focal_gamma=5.0, epochs=epochs)
+    )
+
+    # 6. Focal loss γ=2 + Reject ×10
+    results.append(
+        train_and_evaluate(
+            "focal_g2_w10",
+            data_dir,
+            cls_loss="focal",
+            focal_gamma=2.0,
+            class_weights={rare_class: 10.0},
+            epochs=epochs,
+        )
+    )
+
+    # 7. Class-balanced focal γ=2 (auto frequency weights)
+    results.append(
+        train_and_evaluate(
+            "cb_focal_g2", data_dir, cls_loss="cb_focal", focal_gamma=2.0, cb_beta=0.999, epochs=epochs
+        )
+    )
+
+    # 8. Class-balanced focal γ=2 + extra Reject ×10
+    results.append(
+        train_and_evaluate(
+            "cb_focal_g2_w10",
+            data_dir,
+            cls_loss="cb_focal",
+            focal_gamma=2.0,
+            cb_beta=0.999,
+            class_weights={rare_class: 10.0},
+            epochs=epochs,
+        )
+    )
+
+    # 9. CE + label smoothing
+    results.append(
+        train_and_evaluate(
+            "ce_label_smooth", data_dir, cls_loss="ce", label_smoothing=0.1, epochs=epochs
+        )
+    )
+
+    # ── Summary ──
+    print("\n" + "=" * 80)
+    print("  CLASSIFICATION LOSS COMPARISON SUMMARY  (50 epochs)")
+    print(f"  Dataset: {data_dir}")
+    print(f"  Classes: {classes}  |  Train counts: {counts}")
+    print(f"  Critical class: '{rare_class}' — boosted with weights 10x / 20x")
+    print("=" * 80)
+    print(f"  {'#':<4} {'Run':<25} {'Top-1 Acc':>10} {'Top-5 Acc':>10}")
+    print(f"  {'─' * 4} {'─' * 25} {'─' * 10} {'─' * 10}")
+    for i, r in enumerate(results, 1):
+        print(f"  {i:<4} {r['run_name']:<25} {r['top1']:>10.4f} {r['top5']:>10.4f}")
+    print("=" * 80)
+    print("  Runs with higher Reject weight will sacrifice some Approve accuracy")
+    print("  to ensure Reject samples are rarely missed (lower false-negative rate).")
+    print("=" * 80)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_classification_loss.py
+++ b/scripts/test_classification_loss.py
@@ -76,6 +76,8 @@ def train_and_evaluate(
     label_smoothing: float = 0.0,
     focal_gamma: float = 2.0,
     cb_beta: float = 0.9999,
+    arcface_margin: float = 0.5,
+    arcface_scale: float = 30.0,
     epochs: int = 50,
 ) -> dict:
     """Train a classification model and return metrics."""
@@ -83,6 +85,8 @@ def train_and_evaluate(
     print(f"  Training: {run_name}")
     print(f"  cls_loss={cls_loss}, class_weights={class_weights}")
     print(f"  label_smoothing={label_smoothing}, focal_gamma={focal_gamma}, cb_beta={cb_beta}")
+    if cls_loss == "arcface":
+        print(f"  arcface_margin={arcface_margin}, arcface_scale={arcface_scale}")
     print(f"  epochs={epochs}")
     print(f"{'=' * 70}\n")
 
@@ -101,6 +105,8 @@ def train_and_evaluate(
         label_smoothing=label_smoothing,
         focal_gamma=focal_gamma,
         cb_beta=cb_beta,
+        arcface_margin=arcface_margin,
+        arcface_scale=arcface_scale,
     )
     if class_weights is not None:
         kwargs["class_weights"] = class_weights
@@ -211,20 +217,46 @@ def main():
         )
     )
 
+    # 10. ArcFace — default margin=0.5, scale=30
+    results.append(
+        train_and_evaluate(
+            "arcface_m05_s30", data_dir, cls_loss="arcface",
+            arcface_margin=0.5, arcface_scale=30.0, epochs=epochs
+        )
+    )
+
+    # 11. ArcFace — larger margin for stricter separation
+    results.append(
+        train_and_evaluate(
+            "arcface_m10_s30", data_dir, cls_loss="arcface",
+            arcface_margin=1.0, arcface_scale=30.0, epochs=epochs
+        )
+    )
+
+    # 12. ArcFace + class_weights boosting Reject
+    results.append(
+        train_and_evaluate(
+            "arcface_m05_w10", data_dir, cls_loss="arcface",
+            arcface_margin=0.5, arcface_scale=30.0,
+            class_weights={rare_class: 10.0}, epochs=epochs
+        )
+    )
+
     # ── Summary ──
     print("\n" + "=" * 80)
-    print("  CLASSIFICATION LOSS COMPARISON SUMMARY  (50 epochs)")
+    print(f"  CLASSIFICATION LOSS COMPARISON SUMMARY  ({epochs} epochs)")
     print(f"  Dataset: {data_dir}")
     print(f"  Classes: {classes}  |  Train counts: {counts}")
     print(f"  Critical class: '{rare_class}' — boosted with weights 10x / 20x")
     print("=" * 80)
-    print(f"  {'#':<4} {'Run':<25} {'Top-1 Acc':>10} {'Top-5 Acc':>10}")
-    print(f"  {'─' * 4} {'─' * 25} {'─' * 10} {'─' * 10}")
+    print(f"  {'#':<4} {'Run':<28} {'Top-1 Acc':>10} {'Top-5 Acc':>10}")
+    print(f"  {'─' * 4} {'─' * 28} {'─' * 10} {'─' * 10}")
     for i, r in enumerate(results, 1):
-        print(f"  {i:<4} {r['run_name']:<25} {r['top1']:>10.4f} {r['top5']:>10.4f}")
+        print(f"  {i:<4} {r['run_name']:<28} {r['top1']:>10.4f} {r['top5']:>10.4f}")
     print("=" * 80)
-    print("  Runs with higher Reject weight will sacrifice some Approve accuracy")
+    print("  Runs with higher Reject weight sacrifice some Approve accuracy")
     print("  to ensure Reject samples are rarely missed (lower false-negative rate).")
+    print("  ArcFace learns angularly separated embeddings for stronger class boundaries.")
     print("=" * 80)
 
 

--- a/scripts/train_model.py
+++ b/scripts/train_model.py
@@ -1,5 +1,6 @@
-from ultralytics import YOLO, settings
 import logging
+
+from ultralytics import YOLO, settings
 
 settings.update({"wandb": True})
 

--- a/tests/test_classification_loss.py
+++ b/tests/test_classification_loss.py
@@ -24,6 +24,9 @@ Tests cover:
  21. init_criterion resets _return_features when switching ArcFace → CE
  22. init_criterion with no args returns plain CE (legacy compat)
  23. ArcFace eval fallback uses CE on logits
+ 24. cb_beta >= 1.0 is clamped to 0.9999
+ 25. CB-Focal with zero-count classes produces finite weights (weight=0)
+ 26. Zero-count classes do NOT distort normalization of present classes
 """
 from __future__ import annotations
 
@@ -529,6 +532,84 @@ def test_arcface_eval_fallback_uses_logits():
     print(f"[PASS] ArcFace eval fallback = CE on logits: {loss.item():.5f}")
 
 
+# ──────────────────────────────────────── 24. cb_beta=1.0 clamped ─────────────
+def test_cb_beta_one_clamped():
+    """cb_beta >= 1.0 should be clamped to 0.9999 to avoid division by zero."""
+    counts = [100, 50, 10]
+    # Should not raise — beta is silently clamped
+    loss_fn = v8ClassificationLoss(cls_loss="cb_focal", class_counts=counts, cb_beta=1.0)
+    assert loss_fn.cb_beta == 0.9999, f"Expected cb_beta=0.9999, got {loss_fn.cb_beta}"
+    assert loss_fn._weight is not None
+    assert torch.isfinite(loss_fn._weight).all(), f"Weights contain NaN/Inf: {loss_fn._weight}"
+    print(f"[PASS] cb_beta=1.0 clamped to 0.9999, weights={loss_fn._weight.tolist()}")
+
+
+# ──────────────────────────────────────── 25. CB-Focal zero-count classes ─────
+def test_cb_focal_zero_count_classes():
+    """CB-Focal with zero-count classes should get weight=0 (ignored), not highest weight."""
+    counts = [100, 0, 50]  # class 1 has zero samples
+    loss_fn = v8ClassificationLoss(cls_loss="cb_focal", class_counts=counts, cb_beta=0.999)
+    assert loss_fn._weight is not None
+    assert torch.isfinite(loss_fn._weight).all(), f"Weights contain NaN/Inf: {loss_fn._weight}"
+
+    # Zero-count class must have weight 0 (ignored), not an inflated weight
+    assert loss_fn._weight[1].item() == 0.0, (
+        f"Zero-count class should have weight 0, got {loss_fn._weight[1].item()}"
+    )
+    # Non-zero classes should have positive weight
+    assert loss_fn._weight[0].item() > 0
+    assert loss_fn._weight[2].item() > 0
+
+    # Also test end-to-end: forward should not fail
+    preds = _make_preds(8, 3)
+    batch = _make_batch([0, 2, 0, 2, 0, 2, 0, 2])  # only classes that exist in training
+    loss, _ = loss_fn(preds, batch)
+    assert torch.isfinite(loss), f"Loss is NaN/Inf: {loss.item()}"
+    print(
+        f"[PASS] CB-Focal with zero-count class: weights={loss_fn._weight.tolist()}, "
+        f"class1(absent)=0.0, loss={loss.item():.5f}"
+    )
+
+
+# ──────────────────────────────────────── 26. Zero-count must NOT distort normalization
+def test_cb_focal_zero_count_no_normalization_distortion():
+    """Absent classes (count=0) must not inflate the denominator during normalization.
+
+    If zero-count classes were floored to 1 instead of being zeroed out, they would
+    receive the highest CB-weight (rarest class), inflating the normalization sum and
+    dragging down the weights of all real classes.  This test verifies that the weights
+    for present classes are identical whether or not absent classes exist.
+    """
+    beta = 0.999
+
+    # Scenario A: only present classes
+    counts_no_absent = [100, 50]
+    loss_a = v8ClassificationLoss(cls_loss="cb_focal", class_counts=counts_no_absent, cb_beta=beta)
+
+    # Scenario B: same present classes + an absent class in the middle
+    counts_with_absent = [100, 0, 50]
+    loss_b = v8ClassificationLoss(cls_loss="cb_focal", class_counts=counts_with_absent, cb_beta=beta)
+
+    w_a = loss_a._weight  # [w_cls0, w_cls1]
+    w_b = loss_b._weight  # [w_cls0, 0.0, w_cls2]
+
+    # Absent class must be zero
+    assert w_b[1].item() == 0.0, f"Absent class weight should be 0, got {w_b[1].item()}"
+
+    # Weights for present classes must be identical in both scenarios
+    assert torch.allclose(w_a[0], w_b[0], atol=1e-6), (
+        f"Class 0 weight distorted: no_absent={w_a[0].item():.6f} vs with_absent={w_b[0].item():.6f}"
+    )
+    assert torch.allclose(w_a[1], w_b[2], atol=1e-6), (
+        f"Class 1/2 weight distorted: no_absent={w_a[1].item():.6f} vs with_absent={w_b[2].item():.6f}"
+    )
+
+    print(
+        f"[PASS] Zero-count does NOT distort normalization: "
+        f"no_absent={w_a.tolist()}, with_absent={w_b.tolist()}"
+    )
+
+
 # ──────────────────────────────────────── run all ─────────────────────────────
 if __name__ == "__main__":
     test_default_ce()
@@ -554,6 +635,9 @@ if __name__ == "__main__":
     test_init_criterion_resets_return_features()
     test_init_criterion_no_args()
     test_arcface_eval_fallback_uses_logits()
+    test_cb_beta_one_clamped()
+    test_cb_focal_zero_count_classes()
+    test_cb_focal_zero_count_no_normalization_distortion()
     print("\n" + "=" * 60)
-    print("All 23 tests passed!")
+    print("All 26 tests passed!")
     print("=" * 60)

--- a/tests/test_classification_loss.py
+++ b/tests/test_classification_loss.py
@@ -525,7 +525,7 @@ def test_arcface_eval_fallback_uses_logits():
 
 # ──────────────────────────────────────── 24. cb_beta=1.0 clamped ─────────────
 def test_cb_beta_one_clamped():
-    """cb_beta >= 1.0 should be clamped to 0.9999 to avoid division by zero."""
+    """Cb_beta >= 1.0 should be clamped to 0.9999 to avoid division by zero."""
     counts = [100, 50, 10]
     # Should not raise — beta is silently clamped
     loss_fn = v8ClassificationLoss(cls_loss="cb_focal", class_counts=counts, cb_beta=1.0)
@@ -544,9 +544,7 @@ def test_cb_focal_zero_count_classes():
     assert torch.isfinite(loss_fn._weight).all(), f"Weights contain NaN/Inf: {loss_fn._weight}"
 
     # Zero-count class must have weight 0 (ignored), not an inflated weight
-    assert loss_fn._weight[1].item() == 0.0, (
-        f"Zero-count class should have weight 0, got {loss_fn._weight[1].item()}"
-    )
+    assert loss_fn._weight[1].item() == 0.0, f"Zero-count class should have weight 0, got {loss_fn._weight[1].item()}"
     # Non-zero classes should have positive weight
     assert loss_fn._weight[0].item() > 0
     assert loss_fn._weight[2].item() > 0
@@ -566,10 +564,9 @@ def test_cb_focal_zero_count_classes():
 def test_cb_focal_zero_count_no_normalization_distortion():
     """Absent classes (count=0) must not inflate the denominator during normalization.
 
-    If zero-count classes were floored to 1 instead of being zeroed out, they would
-    receive the highest CB-weight (rarest class), inflating the normalization sum and
-    dragging down the weights of all real classes.  This test verifies that the weights
-    for present classes are identical whether or not absent classes exist.
+    If zero-count classes were floored to 1 instead of being zeroed out, they would receive the highest CB-weight
+    (rarest class), inflating the normalization sum and dragging down the weights of all real classes. This test
+    verifies that the weights for present classes are identical whether or not absent classes exist.
     """
     beta = 0.999
 
@@ -595,10 +592,7 @@ def test_cb_focal_zero_count_no_normalization_distortion():
         f"Class 1/2 weight distorted: no_absent={w_a[1].item():.6f} vs with_absent={w_b[2].item():.6f}"
     )
 
-    print(
-        f"[PASS] Zero-count does NOT distort normalization: "
-        f"no_absent={w_a.tolist()}, with_absent={w_b.tolist()}"
-    )
+    print(f"[PASS] Zero-count does NOT distort normalization: no_absent={w_a.tolist()}, with_absent={w_b.tolist()}")
 
 
 # ──────────────────────────────────────── run all ─────────────────────────────

--- a/tests/test_classification_loss.py
+++ b/tests/test_classification_loss.py
@@ -19,12 +19,13 @@ Tests cover:
  16. ArcFace basic forward + backward
  17. ArcFace produces higher loss than CE (due to angular margin)
  18. ArcFace with class_weights differs from without
- 19. ArcFace margin=0, scale=1 ≈ normalised cosine CE
+ 19. ArcFace margin=0, scale=1 ≈ normalized cosine CE
  20. Classify head returns features when _return_features=True
  21. init_criterion resets _return_features when switching ArcFace → CE
  22. init_criterion with no args returns plain CE (legacy compat)
  23. ArcFace eval fallback uses CE on logits
 """
+
 from __future__ import annotations
 
 import sys
@@ -176,9 +177,7 @@ def test_cb_focal_combined_weights():
     loss_fn_combined = v8ClassificationLoss(
         cls_loss="cb_focal", class_counts=counts, class_weights=user_weights, focal_gamma=2.0, cb_beta=0.999
     )
-    loss_fn_auto = v8ClassificationLoss(
-        cls_loss="cb_focal", class_counts=counts, focal_gamma=2.0, cb_beta=0.999
-    )
+    loss_fn_auto = v8ClassificationLoss(cls_loss="cb_focal", class_counts=counts, focal_gamma=2.0, cb_beta=0.999)
 
     preds = _make_preds(8, 5)
     batch = _make_batch([0, 1, 2, 3, 4, 0, 1, 1])
@@ -186,13 +185,8 @@ def test_cb_focal_combined_weights():
     loss_combined, _ = loss_fn_combined(preds, batch)
     loss_auto, _ = loss_fn_auto(preds, batch)
 
-    assert not torch.allclose(loss_combined, loss_auto, atol=1e-4), (
-        "Combined weights should differ from auto-only"
-    )
-    print(
-        f"[PASS] cb_focal + user weights: combined={loss_combined.item():.5f}, "
-        f"auto={loss_auto.item():.5f}"
-    )
+    assert not torch.allclose(loss_combined, loss_auto, atol=1e-4), "Combined weights should differ from auto-only"
+    print(f"[PASS] cb_focal + user weights: combined={loss_combined.item():.5f}, auto={loss_auto.item():.5f}")
 
 
 # ──────────────────────────────────────── 9. Invalid cls_loss ────────────────
@@ -247,9 +241,7 @@ def test_resolve_class_weights_dict():
 
     trainer._resolve_class_weights()
 
-    assert trainer.args.class_weights_resolved == [3.0, 1.0, 5.0], (
-        f"Got {trainer.args.class_weights_resolved}"
-    )
+    assert trainer.args.class_weights_resolved == [3.0, 1.0, 5.0], f"Got {trainer.args.class_weights_resolved}"
     print(f"[PASS] resolve_class_weights dict: {trainer.args.class_weights_resolved}")
 
 
@@ -304,9 +296,7 @@ def test_higher_gamma_reduces_easy_loss():
     assert loss_high < loss_low, (
         f"Higher γ should reduce easy loss: γ=0.5 → {loss_low.item():.6f}, γ=5.0 → {loss_high.item():.6f}"
     )
-    print(
-        f"[PASS] higher gamma focuses more: γ=0.5={loss_low.item():.6f}, γ=5.0={loss_high.item():.6f}"
-    )
+    print(f"[PASS] higher gamma focuses more: γ=0.5={loss_low.item():.6f}, γ=5.0={loss_high.item():.6f}")
 
 
 # ──────────────────────────────────────── 16. ArcFace basic ───────────────────
@@ -326,9 +316,7 @@ def test_arcface_basic():
     """ArcFace loss should be computable and differentiable."""
     nc, feat_dim, bs = 5, 128, 8
     fc_weight = _make_fc_weight(nc, feat_dim)
-    loss_fn = v8ClassificationLoss(
-        cls_loss="arcface", arcface_margin=0.5, arcface_scale=30.0, fc_weight=fc_weight
-    )
+    loss_fn = v8ClassificationLoss(cls_loss="arcface", arcface_margin=0.5, arcface_scale=30.0, fc_weight=fc_weight)
 
     features = _make_features(bs, feat_dim)
     batch = _make_batch([0, 1, 2, 3, 4, 0, 1, 2])
@@ -344,7 +332,7 @@ def test_arcface_basic():
 
 # ──────────────────────────────────────── 17. ArcFace > CE ────────────────────
 def test_arcface_higher_than_ce_equivalent():
-    """ArcFace with margin > 0 should produce higher loss than normalised cosine CE (margin=0)."""
+    """ArcFace with margin > 0 should produce higher loss than normalized cosine CE (margin=0)."""
     nc, feat_dim, bs = 5, 128, 16
     fc_weight = _make_fc_weight(nc, feat_dim)
 
@@ -365,8 +353,7 @@ def test_arcface_higher_than_ce_equivalent():
         f"Margin should increase loss: margin={loss_margin.item():.5f} > no_margin={loss_no_margin.item():.5f}"
     )
     print(
-        f"[PASS] ArcFace margin increases loss: m=0.5 → {loss_margin.item():.5f}, "
-        f"m=0.0 → {loss_no_margin.item():.5f}"
+        f"[PASS] ArcFace margin increases loss: m=0.5 → {loss_margin.item():.5f}, m=0.0 → {loss_no_margin.item():.5f}"
     )
 
 
@@ -378,11 +365,16 @@ def test_arcface_with_class_weights():
     weights = [1.0, 1.0, 1.0, 1.0, 5.0]
 
     loss_fn_w = v8ClassificationLoss(
-        cls_loss="arcface", arcface_margin=0.5, arcface_scale=30.0,
-        fc_weight=fc_weight, class_weights=weights,
+        cls_loss="arcface",
+        arcface_margin=0.5,
+        arcface_scale=30.0,
+        fc_weight=fc_weight,
+        class_weights=weights,
     )
     loss_fn_u = v8ClassificationLoss(
-        cls_loss="arcface", arcface_margin=0.5, arcface_scale=30.0,
+        cls_loss="arcface",
+        arcface_margin=0.5,
+        arcface_scale=30.0,
         fc_weight=fc_weight,
     )
 
@@ -402,15 +394,13 @@ def test_arcface_zero_margin():
     nc, feat_dim, bs = 3, 64, 8
     fc_weight = _make_fc_weight(nc, feat_dim)
 
-    loss_fn = v8ClassificationLoss(
-        cls_loss="arcface", arcface_margin=0.0, arcface_scale=1.0, fc_weight=fc_weight
-    )
+    loss_fn = v8ClassificationLoss(cls_loss="arcface", arcface_margin=0.0, arcface_scale=1.0, fc_weight=fc_weight)
     features = _make_features(bs, feat_dim)
     batch = _make_batch([0, 1, 2, 0, 1, 2, 0, 1])
 
     loss_af, _ = loss_fn(features, batch)
 
-    # Manual cosine CE: normalise feat & weight, compute cos, cross_entropy
+    # Manual cosine CE: normalize feat & weight, compute cos, cross_entropy
     with torch.no_grad():
         feat_n = torch.nn.functional.normalize(features, dim=1)
         w_n = torch.nn.functional.normalize(fc_weight, dim=1)
@@ -472,9 +462,7 @@ def test_init_criterion_resets_return_features():
     criterion = model.init_criterion()
 
     # Head flag must be reset
-    assert head._return_features is False, (
-        "_return_features should be False after switching from ArcFace to CE"
-    )
+    assert head._return_features is False, "_return_features should be False after switching from ArcFace to CE"
     # Criterion should be plain CE
     assert criterion.cls_loss == "ce"
     print("[PASS] init_criterion resets _return_features when cls_loss != 'arcface'")
@@ -511,7 +499,10 @@ def test_arcface_eval_fallback_uses_logits():
     nc, feat_dim, bs = 5, 128, 8
     fc_weight = _make_fc_weight(nc, feat_dim)
     loss_fn = v8ClassificationLoss(
-        cls_loss="arcface", arcface_margin=0.5, arcface_scale=30.0, fc_weight=fc_weight,
+        cls_loss="arcface",
+        arcface_margin=0.5,
+        arcface_scale=30.0,
+        fc_weight=fc_weight,
     )
 
     # Simulate eval-mode output: (probs, logits)

--- a/tests/test_classification_loss.py
+++ b/tests/test_classification_loss.py
@@ -14,6 +14,16 @@ Tests cover:
  11. ClassificationTrainer._resolve_class_weights (dict)
  12. ClassificationTrainer._resolve_class_weights (list)
  13. ClassificationTrainer._resolve_class_weights (missing classes default to 1.0)
+ 14. Focal γ=0 ≈ CE
+ 15. Higher gamma focuses more on hard examples
+ 16. ArcFace basic forward + backward
+ 17. ArcFace produces higher loss than CE (due to angular margin)
+ 18. ArcFace with class_weights differs from without
+ 19. ArcFace margin=0, scale=1 ≈ normalised cosine CE
+ 20. Classify head returns features when _return_features=True
+ 21. init_criterion resets _return_features when switching ArcFace → CE
+ 22. init_criterion with no args returns plain CE (legacy compat)
+ 23. ArcFace eval fallback uses CE on logits
 """
 from __future__ import annotations
 
@@ -299,6 +309,226 @@ def test_higher_gamma_reduces_easy_loss():
     )
 
 
+# ──────────────────────────────────────── 16. ArcFace basic ───────────────────
+def _make_fc_weight(nc: int, feat_dim: int, device: str = "cpu") -> torch.nn.Parameter:
+    """Create a mock FC weight parameter (nc, feat_dim)."""
+    torch.manual_seed(123)
+    return torch.nn.Parameter(torch.randn(nc, feat_dim, device=device))
+
+
+def _make_features(batch_size: int, feat_dim: int, device: str = "cpu") -> torch.Tensor:
+    """Return raw features (B, feat_dim)."""
+    torch.manual_seed(42)
+    return torch.randn(batch_size, feat_dim, device=device, requires_grad=True)
+
+
+def test_arcface_basic():
+    """ArcFace loss should be computable and differentiable."""
+    nc, feat_dim, bs = 5, 128, 8
+    fc_weight = _make_fc_weight(nc, feat_dim)
+    loss_fn = v8ClassificationLoss(
+        cls_loss="arcface", arcface_margin=0.5, arcface_scale=30.0, fc_weight=fc_weight
+    )
+
+    features = _make_features(bs, feat_dim)
+    batch = _make_batch([0, 1, 2, 3, 4, 0, 1, 2])
+
+    loss, loss_det = loss_fn(features, batch)
+    loss.backward()
+
+    assert loss.item() > 0, "ArcFace loss should be positive"
+    assert features.grad is not None, "ArcFace loss should be differentiable w.r.t. features"
+    assert loss_det.requires_grad is False
+    print(f"[PASS] ArcFace basic: loss={loss.item():.5f}")
+
+
+# ──────────────────────────────────────── 17. ArcFace > CE ────────────────────
+def test_arcface_higher_than_ce_equivalent():
+    """ArcFace with margin > 0 should produce higher loss than normalised cosine CE (margin=0)."""
+    nc, feat_dim, bs = 5, 128, 16
+    fc_weight = _make_fc_weight(nc, feat_dim)
+
+    loss_fn_margin = v8ClassificationLoss(
+        cls_loss="arcface", arcface_margin=0.5, arcface_scale=30.0, fc_weight=fc_weight
+    )
+    loss_fn_no_margin = v8ClassificationLoss(
+        cls_loss="arcface", arcface_margin=0.0, arcface_scale=30.0, fc_weight=fc_weight
+    )
+
+    features = _make_features(bs, feat_dim)
+    batch = _make_batch(list(range(nc)) * (bs // nc) + list(range(bs % nc)))
+
+    loss_margin, _ = loss_fn_margin(features, batch)
+    loss_no_margin, _ = loss_fn_no_margin(features.detach().clone().requires_grad_(True), batch)
+
+    assert loss_margin > loss_no_margin, (
+        f"Margin should increase loss: margin={loss_margin.item():.5f} > no_margin={loss_no_margin.item():.5f}"
+    )
+    print(
+        f"[PASS] ArcFace margin increases loss: m=0.5 → {loss_margin.item():.5f}, "
+        f"m=0.0 → {loss_no_margin.item():.5f}"
+    )
+
+
+# ──────────────────────────────────────── 18. ArcFace + class_weights ─────────
+def test_arcface_with_class_weights():
+    """ArcFace with class_weights should produce different loss than without."""
+    nc, feat_dim, bs = 5, 128, 8
+    fc_weight = _make_fc_weight(nc, feat_dim)
+    weights = [1.0, 1.0, 1.0, 1.0, 5.0]
+
+    loss_fn_w = v8ClassificationLoss(
+        cls_loss="arcface", arcface_margin=0.5, arcface_scale=30.0,
+        fc_weight=fc_weight, class_weights=weights,
+    )
+    loss_fn_u = v8ClassificationLoss(
+        cls_loss="arcface", arcface_margin=0.5, arcface_scale=30.0,
+        fc_weight=fc_weight,
+    )
+
+    features = _make_features(bs, feat_dim)
+    batch = _make_batch([0, 1, 2, 3, 4, 0, 1, 4])
+
+    loss_w, _ = loss_fn_w(features, batch)
+    loss_u, _ = loss_fn_u(features.detach().clone().requires_grad_(True), batch)
+
+    assert not torch.allclose(loss_w, loss_u, atol=1e-4), "ArcFace w/ weights should differ"
+    print(f"[PASS] ArcFace + weights: weighted={loss_w.item():.5f}, unweighted={loss_u.item():.5f}")
+
+
+# ──────────────────────────────────────── 19. ArcFace margin=0 ≈ cosine CE ───
+def test_arcface_zero_margin():
+    """ArcFace with margin=0 and scale=1 should equal normalised-cosine CE."""
+    nc, feat_dim, bs = 3, 64, 8
+    fc_weight = _make_fc_weight(nc, feat_dim)
+
+    loss_fn = v8ClassificationLoss(
+        cls_loss="arcface", arcface_margin=0.0, arcface_scale=1.0, fc_weight=fc_weight
+    )
+    features = _make_features(bs, feat_dim)
+    batch = _make_batch([0, 1, 2, 0, 1, 2, 0, 1])
+
+    loss_af, _ = loss_fn(features, batch)
+
+    # Manual cosine CE: normalise feat & weight, compute cos, cross_entropy
+    with torch.no_grad():
+        feat_n = torch.nn.functional.normalize(features, dim=1)
+        w_n = torch.nn.functional.normalize(fc_weight, dim=1)
+        cos_logits = feat_n @ w_n.T  # scale=1
+        expected = torch.nn.functional.cross_entropy(cos_logits, batch["cls"])
+
+    assert torch.allclose(loss_af, expected, atol=1e-4), (
+        f"ArcFace m=0,s=1 should ≈ cosine CE: af={loss_af.item():.5f}, expected={expected.item():.5f}"
+    )
+    print(f"[PASS] ArcFace m=0, s=1 ≈ cosine CE: {loss_af.item():.5f} ≈ {expected.item():.5f}")
+
+
+# ──────────────────────────────────────── 20. Classify _return_features ───────
+def test_classify_return_features():
+    """Classify head should return features (not logits) when _return_features=True."""
+    from ultralytics.nn.modules.head import Classify
+
+    head = Classify(c1=256, c2=10)
+    head.train()
+    x = torch.randn(2, 256, 8, 8)
+
+    # Normal mode: returns logits (B, 10)
+    out_normal = head(x)
+    assert out_normal.shape == (2, 10), f"Expected (2,10) logits, got {out_normal.shape}"
+
+    # ArcFace mode: returns features (B, 1280)
+    head._return_features = True
+    out_features = head(x)
+    assert out_features.shape == (2, 1280), f"Expected (2,1280) features, got {out_features.shape}"
+
+    # Eval mode: should still return normal (probs, logits) regardless of flag
+    head.eval()
+    out_eval = head(x)
+    assert isinstance(out_eval, tuple) and len(out_eval) == 2, "Eval should return (probs, logits)"
+    assert out_eval[0].shape == (2, 10)
+
+    print("[PASS] Classify _return_features works correctly")
+
+
+# ──────────────────────────────────────── 21. Backward compat: ArcFace→CE ────
+def test_init_criterion_resets_return_features():
+    """Switching from ArcFace to CE should reset _return_features on the Classify head."""
+    from types import SimpleNamespace
+
+    from ultralytics.nn.modules.head import Classify
+    from ultralytics.nn.tasks import ClassificationModel
+
+    # Build a minimal ClassificationModel via __new__ then manually init nn.Module internals
+    model = ClassificationModel.__new__(ClassificationModel)
+    torch.nn.Module.__init__(model)
+    head = Classify(c1=256, c2=5)
+    model.model = torch.nn.ModuleList([head])
+
+    # Simulate: previously trained with ArcFace (instance attr set to True)
+    head._return_features = True
+
+    # Now retrain with plain CE
+    model.args = SimpleNamespace(cls_loss="ce")
+    criterion = model.init_criterion()
+
+    # Head flag must be reset
+    assert head._return_features is False, (
+        "_return_features should be False after switching from ArcFace to CE"
+    )
+    # Criterion should be plain CE
+    assert criterion.cls_loss == "ce"
+    print("[PASS] init_criterion resets _return_features when cls_loss != 'arcface'")
+
+
+# ──────────────────────────────────────── 22. No-args backward compat ─────────
+def test_init_criterion_no_args():
+    """ClassificationModel.init_criterion with no args returns plain CE (full backward compat)."""
+    from ultralytics.nn.modules.head import Classify
+    from ultralytics.nn.tasks import ClassificationModel
+
+    model = ClassificationModel.__new__(ClassificationModel)
+    torch.nn.Module.__init__(model)
+    model.model = torch.nn.ModuleList([Classify(c1=256, c2=5)])
+
+    # No args attribute at all — mimics legacy models
+    criterion = model.init_criterion()
+    assert criterion.cls_loss == "ce"
+    assert criterion._fc_weight is None
+    assert criterion._weight is None
+    assert criterion.label_smoothing == 0.0
+
+    # Head should not have been touched
+    head: Classify = model.model[-1]
+    assert head._return_features is False
+    print("[PASS] init_criterion with no args returns plain CE")
+
+
+# ──────────────────────────────────────── 23. ArcFace eval fallback ───────────
+def test_arcface_eval_fallback_uses_logits():
+    """During eval, ArcFace loss should gracefully fall back to CE on logits."""
+    import torch.nn.functional as F
+
+    nc, feat_dim, bs = 5, 128, 8
+    fc_weight = _make_fc_weight(nc, feat_dim)
+    loss_fn = v8ClassificationLoss(
+        cls_loss="arcface", arcface_margin=0.5, arcface_scale=30.0, fc_weight=fc_weight,
+    )
+
+    # Simulate eval-mode output: (probs, logits)
+    torch.manual_seed(42)
+    logits = torch.randn(bs, nc)
+    probs = logits.softmax(1)
+    preds_eval = (probs, logits)
+    batch = _make_batch([0, 1, 2, 3, 4, 0, 1, 2])
+
+    loss, _ = loss_fn(preds_eval, batch)
+    expected = F.cross_entropy(logits, batch["cls"])
+    assert torch.allclose(loss, expected, atol=1e-5), (
+        f"Eval fallback should be CE on logits: {loss.item():.5f} vs {expected.item():.5f}"
+    )
+    print(f"[PASS] ArcFace eval fallback = CE on logits: {loss.item():.5f}")
+
+
 # ──────────────────────────────────────── run all ─────────────────────────────
 if __name__ == "__main__":
     test_default_ce()
@@ -316,6 +546,14 @@ if __name__ == "__main__":
     test_resolve_class_weights_list()
     test_resolve_class_weights_none()
     test_higher_gamma_reduces_easy_loss()
+    test_arcface_basic()
+    test_arcface_higher_than_ce_equivalent()
+    test_arcface_with_class_weights()
+    test_arcface_zero_margin()
+    test_classify_return_features()
+    test_init_criterion_resets_return_features()
+    test_init_criterion_no_args()
+    test_arcface_eval_fallback_uses_logits()
     print("\n" + "=" * 60)
-    print("All 15 tests passed!")
+    print("All 23 tests passed!")
     print("=" * 60)

--- a/tests/test_classification_loss.py
+++ b/tests/test_classification_loss.py
@@ -445,7 +445,7 @@ def test_classify_return_features():
 
 # ──────────────────────────────────────── 21. Backward compat: ArcFace→CE ────
 def test_init_criterion_resets_return_features():
-    """Switching from ArcFace to CE should reset _return_features on the Classify head."""
+    """Switching from ArcFace to CE should reset _return_features and unfreeze bias."""
     from types import SimpleNamespace
 
     from ultralytics.nn.modules.head import Classify
@@ -457,18 +457,20 @@ def test_init_criterion_resets_return_features():
     head = Classify(c1=256, c2=5)
     model.model = torch.nn.ModuleList([head])
 
-    # Simulate: previously trained with ArcFace (instance attr set to True)
-    head._return_features = True
+    # 1. Init with ArcFace → _return_features=True, bias frozen
+    model.args = SimpleNamespace(cls_loss="arcface")
+    criterion_af = model.init_criterion()
+    assert head._return_features is True
+    assert head.linear.bias.requires_grad is False, "ArcFace should freeze linear.bias"
+    assert criterion_af.cls_loss == "arcface"
 
-    # Now retrain with plain CE
+    # 2. Switch to CE → _return_features=False, bias unfrozen
     model.args = SimpleNamespace(cls_loss="ce")
-    criterion = model.init_criterion()
-
-    # Head flag must be reset
+    criterion_ce = model.init_criterion()
     assert head._return_features is False, "_return_features should be False after switching from ArcFace to CE"
-    # Criterion should be plain CE
-    assert criterion.cls_loss == "ce"
-    print("[PASS] init_criterion resets _return_features when cls_loss != 'arcface'")
+    assert head.linear.bias.requires_grad is True, "Switching to CE should unfreeze linear.bias"
+    assert criterion_ce.cls_loss == "ce"
+    print("[PASS] init_criterion resets _return_features and unfreezes bias when cls_loss != 'arcface'")
 
 
 # ──────────────────────────────────────── 22. No-args backward compat ─────────

--- a/tests/test_classification_loss.py
+++ b/tests/test_classification_loss.py
@@ -1,0 +1,321 @@
+"""Unit tests for the enhanced v8ClassificationLoss with multiple loss types.
+
+Tests cover:
+  1. Default CE loss (backward-compatible)
+  2. Weighted CE loss (user-defined class_weights)
+  3. CE + label smoothing
+  4. Focal loss (no weights)
+  5. Focal loss + class_weights
+  6. Focal loss + label smoothing
+  7. Class-balanced focal loss (auto weights from class_counts)
+  8. Class-balanced focal + user class_weights (combined)
+  9. Invalid cls_loss raises ValueError
+ 10. Weight device migration
+ 11. ClassificationTrainer._resolve_class_weights (dict)
+ 12. ClassificationTrainer._resolve_class_weights (list)
+ 13. ClassificationTrainer._resolve_class_weights (missing classes default to 1.0)
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+# Ensure the local ultralytics package is used
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from ultralytics.utils.loss import v8ClassificationLoss
+
+
+# ──────────────────────────────────────── helpers ─────────────────────────────
+def _make_batch(targets: list[int], device: str = "cpu") -> dict[str, torch.Tensor]:
+    return {"cls": torch.tensor(targets, dtype=torch.long, device=device)}
+
+
+def _make_preds(batch_size: int, nc: int, device: str = "cpu") -> torch.Tensor:
+    """Return raw logits (B, nc) — simulates model output before softmax."""
+    torch.manual_seed(42)
+    return torch.randn(batch_size, nc, device=device, requires_grad=True)
+
+
+# ──────────────────────────────────────── 1. Default CE ──────────────────────
+def test_default_ce():
+    """Default v8ClassificationLoss matches plain cross_entropy."""
+    loss_fn = v8ClassificationLoss()
+    preds = _make_preds(8, 5)
+    batch = _make_batch([0, 1, 2, 3, 4, 0, 1, 2])
+
+    loss, loss_det = loss_fn(preds, batch)
+    expected = torch.nn.functional.cross_entropy(preds, batch["cls"])
+
+    assert torch.allclose(loss, expected, atol=1e-5), f"{loss.item()} != {expected.item()}"
+    assert loss_det.requires_grad is False
+    print(f"[PASS] default CE: loss={loss.item():.5f}")
+
+
+# ──────────────────────────────────────── 2. Weighted CE ─────────────────────
+def test_weighted_ce():
+    """Weighted CE should differ from unweighted when weights are non-uniform."""
+    weights = [1.0, 1.0, 1.0, 1.0, 5.0]
+    loss_fn_w = v8ClassificationLoss(cls_loss="ce", class_weights=weights)
+    loss_fn_u = v8ClassificationLoss(cls_loss="ce")
+
+    preds = _make_preds(8, 5)
+    batch = _make_batch([0, 1, 2, 3, 4, 0, 1, 4])
+
+    loss_w, _ = loss_fn_w(preds, batch)
+    loss_u, _ = loss_fn_u(preds, batch)
+
+    assert not torch.allclose(loss_w, loss_u, atol=1e-4), "Weighted and unweighted CE should differ"
+    print(f"[PASS] weighted CE: weighted={loss_w.item():.5f}, unweighted={loss_u.item():.5f}")
+
+
+# ──────────────────────────────────────── 3. CE + label smoothing ────────────
+def test_ce_label_smoothing():
+    """CE with label smoothing should produce a different loss than without."""
+    loss_fn_ls = v8ClassificationLoss(cls_loss="ce", label_smoothing=0.1)
+    loss_fn_no = v8ClassificationLoss(cls_loss="ce", label_smoothing=0.0)
+
+    preds = _make_preds(8, 5)
+    batch = _make_batch([0, 1, 2, 3, 4, 0, 1, 2])
+
+    loss_ls, _ = loss_fn_ls(preds, batch)
+    loss_no, _ = loss_fn_no(preds, batch)
+
+    assert not torch.allclose(loss_ls, loss_no, atol=1e-5), "Label smoothing should change the loss"
+    print(f"[PASS] label smoothing: smoothed={loss_ls.item():.5f}, raw={loss_no.item():.5f}")
+
+
+# ──────────────────────────────────────── 4. Focal loss (no weights) ─────────
+def test_focal_no_weights():
+    """Focal loss should be computable and differentiable."""
+    loss_fn = v8ClassificationLoss(cls_loss="focal", focal_gamma=2.0)
+    preds = _make_preds(8, 5)
+    batch = _make_batch([0, 1, 2, 3, 4, 0, 1, 2])
+
+    loss, _ = loss_fn(preds, batch)
+    loss.backward()
+
+    assert loss.item() > 0, "Focal loss should be positive"
+    assert preds.grad is not None, "Focal loss should be differentiable"
+    print(f"[PASS] focal (γ=2.0, no weights): loss={loss.item():.5f}")
+
+
+# ──────────────────────────────────────── 5. Focal + class_weights ───────────
+def test_focal_with_class_weights():
+    """Focal loss with class_weights should differ from without."""
+    weights = [1.0, 1.0, 1.0, 1.0, 5.0]
+    loss_fn_w = v8ClassificationLoss(cls_loss="focal", focal_gamma=2.0, class_weights=weights)
+    loss_fn_u = v8ClassificationLoss(cls_loss="focal", focal_gamma=2.0)
+
+    preds = _make_preds(8, 5)
+    batch = _make_batch([0, 1, 2, 3, 4, 0, 1, 4])
+
+    loss_w, _ = loss_fn_w(preds, batch)
+    loss_u, _ = loss_fn_u(preds, batch)
+
+    assert not torch.allclose(loss_w, loss_u, atol=1e-4), "Focal w/ weights should differ from w/o"
+    print(f"[PASS] focal + weights: weighted={loss_w.item():.5f}, unweighted={loss_u.item():.5f}")
+
+
+# ──────────────────────────────────────── 6. Focal + label smoothing ─────────
+def test_focal_label_smoothing():
+    """Focal loss with label smoothing should differ from without."""
+    loss_fn_ls = v8ClassificationLoss(cls_loss="focal", focal_gamma=2.0, label_smoothing=0.1)
+    loss_fn_no = v8ClassificationLoss(cls_loss="focal", focal_gamma=2.0, label_smoothing=0.0)
+
+    preds = _make_preds(8, 5)
+    batch = _make_batch([0, 1, 2, 3, 4, 0, 1, 2])
+
+    loss_ls, _ = loss_fn_ls(preds, batch)
+    loss_no, _ = loss_fn_no(preds, batch)
+
+    assert not torch.allclose(loss_ls, loss_no, atol=1e-5)
+    print(f"[PASS] focal + label smoothing: smoothed={loss_ls.item():.5f}, raw={loss_no.item():.5f}")
+
+
+# ──────────────────────────────────────── 7. CB Focal (auto weights) ─────────
+def test_cb_focal_auto_weights():
+    """Class-balanced focal loss should compute effective-number weights from counts."""
+    # Imbalanced: class 0 has 1000 samples, class 1 has 10
+    counts = [1000, 10, 500, 100, 50]
+    loss_fn = v8ClassificationLoss(cls_loss="cb_focal", class_counts=counts, focal_gamma=2.0, cb_beta=0.999)
+
+    preds = _make_preds(8, 5)
+    batch = _make_batch([0, 1, 2, 3, 4, 0, 1, 1])
+
+    loss, _ = loss_fn(preds, batch)
+    loss.backward()
+
+    assert loss.item() > 0
+    assert preds.grad is not None
+    # Verify internal weight tensor exists and is normalized
+    assert loss_fn._weight is not None
+    print(f"[PASS] cb_focal (auto weights): loss={loss.item():.5f}, weights={loss_fn._weight.tolist()}")
+
+
+# ──────────────────────────────────────── 8. CB Focal + user weights ─────────
+def test_cb_focal_combined_weights():
+    """CB focal with user class_weights should combine both weight sources."""
+    counts = [1000, 10, 500, 100, 50]
+    user_weights = [1.0, 5.0, 1.0, 1.0, 1.0]
+
+    loss_fn_combined = v8ClassificationLoss(
+        cls_loss="cb_focal", class_counts=counts, class_weights=user_weights, focal_gamma=2.0, cb_beta=0.999
+    )
+    loss_fn_auto = v8ClassificationLoss(
+        cls_loss="cb_focal", class_counts=counts, focal_gamma=2.0, cb_beta=0.999
+    )
+
+    preds = _make_preds(8, 5)
+    batch = _make_batch([0, 1, 2, 3, 4, 0, 1, 1])
+
+    loss_combined, _ = loss_fn_combined(preds, batch)
+    loss_auto, _ = loss_fn_auto(preds, batch)
+
+    assert not torch.allclose(loss_combined, loss_auto, atol=1e-4), (
+        "Combined weights should differ from auto-only"
+    )
+    print(
+        f"[PASS] cb_focal + user weights: combined={loss_combined.item():.5f}, "
+        f"auto={loss_auto.item():.5f}"
+    )
+
+
+# ──────────────────────────────────────── 9. Invalid cls_loss ────────────────
+def test_invalid_cls_loss():
+    """An unsupported cls_loss string should raise ValueError."""
+    with pytest.raises(ValueError, match="Invalid cls_loss"):
+        v8ClassificationLoss(cls_loss="invalid_loss")
+    print("[PASS] invalid cls_loss raises ValueError")
+
+
+# ──────────────────────────────────────── 10. Weight device migration ────────
+def test_weight_device_migration():
+    """Weights should be migrated to the correct device on first forward call."""
+    loss_fn = v8ClassificationLoss(cls_loss="ce", class_weights=[1.0, 2.0, 3.0])
+    assert loss_fn._weight.device == torch.device("cpu")
+
+    preds = _make_preds(4, 3, device="cpu")
+    batch = _make_batch([0, 1, 2, 0], device="cpu")
+    loss, _ = loss_fn(preds, batch)
+
+    assert loss_fn._weight.device == torch.device("cpu")
+    print(f"[PASS] weight device migration: loss={loss.item():.5f}")
+
+
+# ──────────────────────────────────────── 11. Gamma=0 ≈ CE ───────────────────
+def test_focal_gamma_zero_equals_ce():
+    """Focal loss with gamma=0 should approximate standard CE (no focusing)."""
+    loss_fn_focal = v8ClassificationLoss(cls_loss="focal", focal_gamma=0.0)
+    loss_fn_ce = v8ClassificationLoss(cls_loss="ce")
+
+    preds = _make_preds(16, 5)
+    batch = _make_batch([0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 0])
+
+    loss_focal, _ = loss_fn_focal(preds, batch)
+    loss_ce, _ = loss_fn_ce(preds, batch)
+
+    assert torch.allclose(loss_focal, loss_ce, atol=1e-4), (
+        f"Focal γ=0 should ≈ CE: focal={loss_focal.item():.5f}, ce={loss_ce.item():.5f}"
+    )
+    print(f"[PASS] focal γ=0 ≈ CE: focal={loss_focal.item():.5f}, ce={loss_ce.item():.5f}")
+
+
+# ──────────────────────────────────────── 12. Resolve class_weights dict ─────
+def test_resolve_class_weights_dict():
+    """ClassificationTrainer._resolve_class_weights should handle dict input."""
+    from ultralytics.models.yolo.classify.train import ClassificationTrainer
+
+    trainer = object.__new__(ClassificationTrainer)
+    trainer.args = SimpleNamespace(class_weights={"cat": 3.0, "bird": 5.0})
+    trainer.data = {"nc": 3, "names": {0: "cat", 1: "dog", 2: "bird"}}
+    trainer.model = SimpleNamespace(names={0: "cat", 1: "dog", 2: "bird"})
+
+    trainer._resolve_class_weights()
+
+    assert trainer.args.class_weights_resolved == [3.0, 1.0, 5.0], (
+        f"Got {trainer.args.class_weights_resolved}"
+    )
+    print(f"[PASS] resolve_class_weights dict: {trainer.args.class_weights_resolved}")
+
+
+# ──────────────────────────────────────── 13. Resolve class_weights list ─────
+def test_resolve_class_weights_list():
+    """ClassificationTrainer._resolve_class_weights should handle list input."""
+    from ultralytics.models.yolo.classify.train import ClassificationTrainer
+
+    trainer = object.__new__(ClassificationTrainer)
+    trainer.args = SimpleNamespace(class_weights=[2.0, 3.0, 1.0])
+    trainer.data = {"nc": 3, "names": {0: "cat", 1: "dog", 2: "bird"}}
+    trainer.model = SimpleNamespace(names={0: "cat", 1: "dog", 2: "bird"})
+
+    trainer._resolve_class_weights()
+
+    assert trainer.args.class_weights_resolved == [2.0, 3.0, 1.0]
+    print(f"[PASS] resolve_class_weights list: {trainer.args.class_weights_resolved}")
+
+
+# ──────────────────────────────────────── 14. Resolve — no class_weights ─────
+def test_resolve_class_weights_none():
+    """When class_weights is None, resolved should also be None."""
+    from ultralytics.models.yolo.classify.train import ClassificationTrainer
+
+    trainer = object.__new__(ClassificationTrainer)
+    trainer.args = SimpleNamespace(class_weights=None)
+    trainer.data = {"nc": 3, "names": {0: "cat", 1: "dog", 2: "bird"}}
+    trainer.model = SimpleNamespace(names={0: "cat", 1: "dog", 2: "bird"})
+
+    trainer._resolve_class_weights()
+
+    assert trainer.args.class_weights_resolved is None
+    print("[PASS] resolve_class_weights None -> None")
+
+
+# ──────────────────────────────────────── 15. Higher gamma focuses more ──────
+def test_higher_gamma_reduces_easy_loss():
+    """Higher gamma should reduce loss contribution from well-classified (easy) examples."""
+    # Make preds that are very confident for targets — "easy" examples
+    preds_easy = torch.tensor(
+        [[5.0, -5.0, -5.0], [5.0, -5.0, -5.0], [5.0, -5.0, -5.0], [5.0, -5.0, -5.0]],
+        requires_grad=True,
+    )
+    batch = _make_batch([0, 0, 0, 0])
+
+    loss_fn_low = v8ClassificationLoss(cls_loss="focal", focal_gamma=0.5)
+    loss_fn_high = v8ClassificationLoss(cls_loss="focal", focal_gamma=5.0)
+
+    loss_low, _ = loss_fn_low(preds_easy, batch)
+    loss_high, _ = loss_fn_high(preds_easy.detach().requires_grad_(True), batch)
+
+    assert loss_high < loss_low, (
+        f"Higher γ should reduce easy loss: γ=0.5 → {loss_low.item():.6f}, γ=5.0 → {loss_high.item():.6f}"
+    )
+    print(
+        f"[PASS] higher gamma focuses more: γ=0.5={loss_low.item():.6f}, γ=5.0={loss_high.item():.6f}"
+    )
+
+
+# ──────────────────────────────────────── run all ─────────────────────────────
+if __name__ == "__main__":
+    test_default_ce()
+    test_weighted_ce()
+    test_ce_label_smoothing()
+    test_focal_no_weights()
+    test_focal_with_class_weights()
+    test_focal_label_smoothing()
+    test_cb_focal_auto_weights()
+    test_cb_focal_combined_weights()
+    test_invalid_cls_loss()
+    test_weight_device_migration()
+    test_focal_gamma_zero_equals_ce()
+    test_resolve_class_weights_dict()
+    test_resolve_class_weights_list()
+    test_resolve_class_weights_none()
+    test_higher_gamma_reduces_easy_loss()
+    print("\n" + "=" * 60)
+    print("All 15 tests passed!")
+    print("=" * 60)

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -498,7 +498,7 @@ def check_dict_alignment(
     base_keys, custom_keys = (frozenset(x.keys()) for x in (base, custom))
     # Allow 'augmentations' as a valid custom parameter for custom Albumentations transforms
     if allowed_custom_keys is None:
-        allowed_custom_keys = {"augmentations", "save_dir", "class_weights_resolved", "class_counts", "fc_weight"}
+        allowed_custom_keys = {"augmentations", "save_dir"}
     if mismatched := [k for k in custom_keys if k not in base_keys and k not in allowed_custom_keys]:
         from difflib import get_close_matches
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -449,7 +449,7 @@ def _handle_deprecation(custom: dict) -> dict:
         "hide_conf": ("show_conf", lambda v: not bool(v)),
         "line_thickness": ("line_width", lambda v: v),
     }
-    removed_keys = {"label_smoothing", "save_hybrid", "crop_fraction"}
+    removed_keys = {"save_hybrid", "crop_fraction"}
 
     for old_key, (new_key, transform) in deprecated_mappings.items():
         if old_key not in custom:

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -160,6 +160,8 @@ CFG_FLOAT_KEYS = frozenset(
         "workspace",
         "batch",
         "focal_gamma",
+        "arcface_margin",
+        "arcface_scale",
     }
 )
 CFG_FRACTION_KEYS = frozenset(
@@ -496,7 +498,7 @@ def check_dict_alignment(
     base_keys, custom_keys = (frozenset(x.keys()) for x in (base, custom))
     # Allow 'augmentations' as a valid custom parameter for custom Albumentations transforms
     if allowed_custom_keys is None:
-        allowed_custom_keys = {"augmentations", "save_dir", "class_weights_resolved", "class_counts"}
+        allowed_custom_keys = {"augmentations", "save_dir", "class_weights_resolved", "class_counts", "fc_weight"}
     if mismatched := [k for k in custom_keys if k not in base_keys and k not in allowed_custom_keys]:
         from difflib import get_close_matches
 

--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -159,6 +159,7 @@ CFG_FLOAT_KEYS = frozenset(
         "time",
         "workspace",
         "batch",
+        "focal_gamma",
     }
 )
 CFG_FRACTION_KEYS = frozenset(
@@ -187,6 +188,8 @@ CFG_FRACTION_KEYS = frozenset(
         "iou",
         "fraction",
         "multi_scale",
+        "label_smoothing",
+        "cb_beta",
     }
 )
 CFG_INT_KEYS = frozenset(
@@ -493,7 +496,7 @@ def check_dict_alignment(
     base_keys, custom_keys = (frozenset(x.keys()) for x in (base, custom))
     # Allow 'augmentations' as a valid custom parameter for custom Albumentations transforms
     if allowed_custom_keys is None:
-        allowed_custom_keys = {"augmentations", "save_dir", "class_weights_resolved"}
+        allowed_custom_keys = {"augmentations", "save_dir", "class_weights_resolved", "class_counts"}
     if mismatched := [k for k in custom_keys if k not in base_keys and k not in allowed_custom_keys]:
         from difflib import get_close_matches
 

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -48,10 +48,12 @@ mask_ratio: 4 # (int) mask downsample ratio (segment only)
 
 # Classification
 dropout: 0.0 # (float) dropout for classification head (classify only)
-cls_loss: ce # (str) classification loss type: 'ce' (cross-entropy), 'focal' (focal loss), 'cb_focal' (class-balanced focal loss) (classify only)
+cls_loss: ce # (str) classification loss type: 'ce' | 'focal' | 'cb_focal' | 'arcface' (classify only)
 label_smoothing: 0.0 # (float) label smoothing factor 0.0-1.0 (classify only); combinable with any cls_loss type
 focal_gamma: 2.0 # (float) focal loss gamma focusing parameter (classify only); used when cls_loss is 'focal' or 'cb_focal'
 cb_beta: 0.9999 # (float) class-balanced loss effective number beta 0.0-1.0 (classify only); used when cls_loss is 'cb_focal'
+arcface_margin: 0.5 # (float) ArcFace additive angular margin in radians (classify only); used when cls_loss is 'arcface'
+arcface_scale: 30.0 # (float) ArcFace logit scale factor (classify only); used when cls_loss is 'arcface'
 
 # Val/Test settings ----------------------------------------------------------------------------------------------------
 val: True # (bool) run validation/testing during training

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -48,6 +48,10 @@ mask_ratio: 4 # (int) mask downsample ratio (segment only)
 
 # Classification
 dropout: 0.0 # (float) dropout for classification head (classify only)
+cls_loss: ce # (str) classification loss type: 'ce' (cross-entropy), 'focal' (focal loss), 'cb_focal' (class-balanced focal loss) (classify only)
+label_smoothing: 0.0 # (float) label smoothing factor 0.0-1.0 (classify only); combinable with any cls_loss type
+focal_gamma: 2.0 # (float) focal loss gamma focusing parameter (classify only); used when cls_loss is 'focal' or 'cb_focal'
+cb_beta: 0.9999 # (float) class-balanced loss effective number beta 0.0-1.0 (classify only); used when cls_loss is 'cb_focal'
 
 # Val/Test settings ----------------------------------------------------------------------------------------------------
 val: True # (bool) run validation/testing during training

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -129,9 +129,7 @@ class ClassificationTrainer(BaseTrainer):
                 counts[cls_idx] += 1
 
         self.args.class_counts = counts
-        LOGGER.info(
-            f"Classification class counts (train): {dict(zip(self.data['names'].values(), counts))}"
-        )
+        LOGGER.info(f"Classification class counts (train): {dict(zip(self.data['names'].values(), counts))}")
 
     def get_model(self, cfg=None, weights=None, verbose: bool = True):
         """Return a modified PyTorch model configured for training YOLO classification.

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -128,6 +128,15 @@ class ClassificationTrainer(BaseTrainer):
             if cls_idx < nc:
                 counts[cls_idx] += 1
 
+        # Warn about zero-count classes.  Their CB-Focal weight will be set to 0
+        # (ignored) by v8ClassificationLoss so they don't distort other weights.
+        zero_classes = [self.data["names"][i] for i, c in enumerate(counts) if c == 0]
+        if zero_classes:
+            LOGGER.warning(
+                f"cls_loss='cb_focal': classes {zero_classes} have 0 training samples; "
+                "their CB-Focal weight will be set to 0 (ignored in loss)."
+            )
+
         self.args.class_counts = counts
         LOGGER.info(
             f"Classification class counts (train): {dict(zip(self.data['names'].values(), counts))}"

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -65,8 +65,73 @@ class ClassificationTrainer(BaseTrainer):
         super().__init__(cfg, overrides, _callbacks)
 
     def set_model_attributes(self):
-        """Set the YOLO model's class names from the loaded dataset."""
+        """Set the YOLO model's class names and classification loss config from the loaded dataset."""
         self.model.names = self.data["names"]
+        self.model.args = self.args  # attach hyperparameters so init_criterion() can read them
+
+        # Resolve class_weights (same logic as DetectionTrainer)
+        self._resolve_class_weights()
+
+        # Compute per-class sample counts from training set for class-balanced losses
+        self._compute_class_counts()
+
+    def _resolve_class_weights(self):
+        """Resolve class_weights config into a list of floats indexed by class ID.
+
+        Accepts either a dict mapping class names to weights or a list of floats (one per class).
+        Classes not specified in a dict default to weight 1.0.
+        """
+        raw = getattr(self.args, "class_weights", None)
+        nc = self.data["nc"]
+        names = self.data["names"]  # {0: 'cat', 1: 'dog', ...}
+
+        if not raw:
+            self.args.class_weights_resolved = None
+            return
+
+        resolved = [1.0] * nc
+        if isinstance(raw, dict):
+            name_to_idx = {v: k for k, v in names.items()}
+            for name, weight in raw.items():
+                if name in name_to_idx:
+                    resolved[name_to_idx[name]] = float(weight)
+                else:
+                    LOGGER.warning(f"class_weights: class '{name}' not found in dataset names, ignoring.")
+        elif isinstance(raw, (list, tuple)):
+            if len(raw) != nc:
+                raise ValueError(f"class_weights list length ({len(raw)}) != number of classes ({nc}).")
+            resolved = [float(w) for w in raw]
+        else:
+            raise TypeError(f"Unsupported class_weights type: {type(raw)}. Expected dict or list.")
+
+        self.args.class_weights_resolved = resolved
+        LOGGER.info(f"Classification class weights resolved: {dict(zip(names.values(), resolved))}")
+
+    def _compute_class_counts(self):
+        """Count training samples per class and store in args for class-balanced loss."""
+        if getattr(self.args, "cls_loss", "ce") != "cb_focal":
+            self.args.class_counts = None
+            return
+
+        nc = self.data["nc"]
+        counts = [0] * nc
+        train_path = self.data.get("train")
+        if train_path is None:
+            LOGGER.warning("cls_loss='cb_focal' but no training path found; falling back to uniform weights.")
+            self.args.class_counts = None
+            return
+
+        # Build a temporary dataset to count samples
+        dataset = self.build_dataset(str(train_path), mode="train")
+        for sample in dataset.samples:
+            cls_idx = sample[1]
+            if cls_idx < nc:
+                counts[cls_idx] += 1
+
+        self.args.class_counts = counts
+        LOGGER.info(
+            f"Classification class counts (train): {dict(zip(self.data['names'].values(), counts))}"
+        )
 
     def get_model(self, cfg=None, weights=None, verbose: bool = True):
         """Return a modified PyTorch model configured for training YOLO classification.

--- a/ultralytics/nn/modules/head.py
+++ b/ultralytics/nn/modules/head.py
@@ -781,6 +781,7 @@ class Classify(nn.Module):
         pool (nn.AdaptiveAvgPool2d): Global average pooling layer.
         drop (nn.Dropout): Dropout layer for regularization.
         linear (nn.Linear): Linear layer for final classification.
+        _return_features (bool): When True (ArcFace mode), return raw features instead of logits during training.
 
     Methods:
         forward: Perform forward pass of the YOLO model on input image data.
@@ -793,6 +794,7 @@ class Classify(nn.Module):
     """
 
     export = False  # export mode
+    _return_features = False  # set True for ArcFace (loss computes its own angular logits)
 
     def __init__(self, c1: int, c2: int, k: int = 1, s: int = 1, p: int | None = None, g: int = 1):
         """Initialize YOLO classification head to transform input tensor from (b,c1,20,20) to (b,c2) shape.
@@ -816,7 +818,10 @@ class Classify(nn.Module):
         """Perform forward pass of the YOLO model on input image data."""
         if isinstance(x, list):
             x = torch.cat(x, 1)
-        x = self.linear(self.drop(self.pool(self.conv(x)).flatten(1)))
+        features = self.drop(self.pool(self.conv(x)).flatten(1))  # (b, c_)
+        if self.training and self._return_features:
+            return features  # ArcFace mode: loss will compute angular logits from features + weight
+        x = self.linear(features)  # (b, c2)
         if self.training:
             return x
         y = x.softmax(1)  # get final output

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -720,7 +720,7 @@ class ClassificationModel(BaseModel):
             if isinstance(head, Classify):
                 head._return_features = True
                 fc_weight = head.linear.weight  # nn.Parameter (nc, feat_dim)
-                # ArcFace operates in angular (normalised) space — the bias is not
+                # ArcFace operates in angular (normalized) space — the bias is not
                 # used during the forward pass (features are returned directly).
                 # Freeze the bias so it doesn't accumulate stale gradients and to
                 # keep parameter management explicit (consistent with the original

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -709,13 +709,37 @@ class ClassificationModel(BaseModel):
         args = getattr(self, "args", None)
         if args is None:
             return v8ClassificationLoss()
+
+        cls_loss = getattr(args, "cls_loss", "ce")
+        fc_weight = None
+
+        # ArcFace requires the Classify head to return features (not logits) during training
+        # and needs a reference to the FC layer's weight for angular margin computation.
+        head = self.model[-1]
+        if cls_loss == "arcface":
+            if isinstance(head, Classify):
+                head._return_features = True
+                fc_weight = head.linear.weight  # nn.Parameter (nc, feat_dim)
+            else:
+                LOGGER.warning(
+                    "cls_loss='arcface' requires a Classify head; falling back to 'ce'."
+                )
+                cls_loss = "ce"
+        elif isinstance(head, Classify):
+            # Ensure _return_features is off when not using ArcFace (safety for
+            # models previously trained with ArcFace and reloaded with a different loss).
+            head._return_features = False
+
         return v8ClassificationLoss(
-            cls_loss=getattr(args, "cls_loss", "ce"),
+            cls_loss=cls_loss,
             class_weights=getattr(args, "class_weights_resolved", None),
             class_counts=getattr(args, "class_counts", None),
             label_smoothing=getattr(args, "label_smoothing", 0.0),
             focal_gamma=getattr(args, "focal_gamma", 2.0),
             cb_beta=getattr(args, "cb_beta", 0.9999),
+            arcface_margin=getattr(args, "arcface_margin", 0.5),
+            arcface_scale=getattr(args, "arcface_scale", 30.0),
+            fc_weight=fc_weight,
         )
 
 

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -706,7 +706,17 @@ class ClassificationModel(BaseModel):
 
     def init_criterion(self):
         """Initialize the loss criterion for the ClassificationModel."""
-        return v8ClassificationLoss()
+        args = getattr(self, "args", None)
+        if args is None:
+            return v8ClassificationLoss()
+        return v8ClassificationLoss(
+            cls_loss=getattr(args, "cls_loss", "ce"),
+            class_weights=getattr(args, "class_weights_resolved", None),
+            class_counts=getattr(args, "class_counts", None),
+            label_smoothing=getattr(args, "label_smoothing", 0.0),
+            focal_gamma=getattr(args, "focal_gamma", 2.0),
+            cb_beta=getattr(args, "cb_beta", 0.9999),
+        )
 
 
 class RTDETRDetectionModel(DetectionModel):

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -720,6 +720,13 @@ class ClassificationModel(BaseModel):
             if isinstance(head, Classify):
                 head._return_features = True
                 fc_weight = head.linear.weight  # nn.Parameter (nc, feat_dim)
+                # ArcFace operates in angular (normalised) space — the bias is not
+                # used during the forward pass (features are returned directly).
+                # Freeze the bias so it doesn't accumulate stale gradients and to
+                # keep parameter management explicit (consistent with the original
+                # ArcFace paper which uses bias=False).
+                if head.linear.bias is not None:
+                    head.linear.bias.requires_grad = False
             else:
                 LOGGER.warning("cls_loss='arcface' requires a Classify head; falling back to 'ce'.")
                 cls_loss = "ce"
@@ -727,6 +734,9 @@ class ClassificationModel(BaseModel):
             # Ensure _return_features is off when not using ArcFace (safety for
             # models previously trained with ArcFace and reloaded with a different loss).
             head._return_features = False
+            # Unfreeze bias in case it was frozen by a previous ArcFace session.
+            if head.linear.bias is not None:
+                head.linear.bias.requires_grad = True
 
         return v8ClassificationLoss(
             cls_loss=cls_loss,

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -721,9 +721,7 @@ class ClassificationModel(BaseModel):
                 head._return_features = True
                 fc_weight = head.linear.weight  # nn.Parameter (nc, feat_dim)
             else:
-                LOGGER.warning(
-                    "cls_loss='arcface' requires a Classify head; falling back to 'ce'."
-                )
+                LOGGER.warning("cls_loss='arcface' requires a Classify head; falling back to 'ce'.")
                 cls_loss = "ce"
         elif isinstance(head, Classify):
             # Ensure _return_features is off when not using ArcFace (safety for

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -13,7 +13,7 @@ from ultralytics.utils import LOGGER
 from ultralytics.utils.metrics import OKS_SIGMA, RLE_WEIGHT
 from ultralytics.utils.ops import crop_mask, xywh2xyxy, xyxy2xywh
 from ultralytics.utils.tal import RotatedTaskAlignedAssigner, TaskAlignedAssigner, dist2bbox, dist2rbox, make_anchors
-from ultralytics.utils.torch_utils import autocast
+from ultralytics.utils.torch_utils import TORCH_1_10, autocast
 
 from .metrics import bbox_iou, probiou
 from .tal import bbox2dist, rbox2dist
@@ -1061,6 +1061,38 @@ class v8ClassificationLoss:
             self._weight_device = device
         return self._weight
 
+    def _cross_entropy_with_smoothing(
+        self,
+        logits: torch.Tensor,
+        targets: torch.Tensor,
+        weight: torch.Tensor | None,
+    ) -> torch.Tensor:
+        """Cross-entropy with label smoothing, compatible with torch < 1.10.
+
+        ``F.cross_entropy(label_smoothing=...)`` was added in PyTorch 1.10.  On older
+        versions we fall back to a manual implementation so the library stays compatible
+        with the declared ``torch>=1.8`` minimum.
+        """
+        if self.label_smoothing == 0.0:
+            return F.cross_entropy(logits, targets, weight=weight, reduction="mean")
+
+        if TORCH_1_10:
+            return F.cross_entropy(
+                logits, targets, weight=weight, reduction="mean", label_smoothing=self.label_smoothing
+            )
+
+        # Manual label-smoothing for torch < 1.10
+        nc = logits.shape[1]
+        log_probs = F.log_softmax(logits, dim=1)  # (B, C)
+        # Smoothed target distribution: (1 - ε) on correct class, ε/(C-1) elsewhere
+        smooth = torch.full_like(log_probs, self.label_smoothing / (nc - 1))
+        smooth.scatter_(1, targets.unsqueeze(1), 1.0 - self.label_smoothing)
+        # Per-sample loss
+        loss = -(smooth * log_probs).sum(dim=1)  # (B,)
+        if weight is not None:
+            loss = loss * weight[targets]
+        return loss.mean()
+
     # ---------------------------------------------------------------------- forward
     def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
         """Compute the classification loss between predictions and true labels."""
@@ -1082,9 +1114,7 @@ class v8ClassificationLoss:
         weight = self._ensure_weight_device(preds.device)
 
         if self.cls_loss == "ce":
-            loss = F.cross_entropy(
-                preds, targets, weight=weight, reduction="mean", label_smoothing=self.label_smoothing
-            )
+            loss = self._cross_entropy_with_smoothing(preds, targets, weight)
         elif self.cls_loss in ("focal", "cb_focal"):
             loss = self._focal_loss(preds, targets, weight)
         else:
@@ -1165,9 +1195,7 @@ class v8ClassificationLoss:
         # Apply per-class importance weights if provided
         weight = self._ensure_weight_device(features.device)
 
-        loss = F.cross_entropy(
-            arcface_logits, targets, weight=weight, reduction="mean", label_smoothing=self.label_smoothing
-        )
+        loss = self._cross_entropy_with_smoothing(arcface_logits, targets, weight)
         return loss, loss.detach()
 
 

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -973,17 +973,25 @@ class v8ClassificationLoss:
         - ``'cb_focal'`` – class-balanced focal loss (Cui et al., 2019) that auto-computes
           effective-number-of-samples weights from ``class_counts`` and multiplies them with
           user-defined ``class_weights`` when provided.
+        - ``'arcface'`` – ArcFace (Deng et al., 2019) additive angular margin loss that learns
+          highly discriminative features by enforcing an angular margin between classes in the
+          embedding space. Requires the Classify head to return features and a reference to the
+          FC layer weight (set up automatically by ``ClassificationModel.init_criterion``).
 
     Args:
-        cls_loss (str): Loss type identifier (``'ce'``, ``'focal'``, or ``'cb_focal'``).
+        cls_loss (str): Loss type identifier (``'ce'``, ``'focal'``, ``'cb_focal'``, or ``'arcface'``).
         class_weights (list[float] | None): Per-class importance weights (length = nc).
         class_counts (list[int] | None): Per-class sample counts from training set (length = nc).
         label_smoothing (float): Label-smoothing factor in ``[0, 1]``.
         focal_gamma (float): Focal-loss focusing parameter γ.
         cb_beta (float): Class-balanced effective-number β in ``[0, 1)``.
+        arcface_margin (float): ArcFace additive angular margin *m* in radians.
+        arcface_scale (float): ArcFace logit re-scaling factor *s*.
+        fc_weight (torch.nn.Parameter | None): Reference to the Classify head's ``linear.weight``
+            parameter (shape ``(nc, feat_dim)``). Required when ``cls_loss='arcface'``.
     """
 
-    _VALID_LOSSES = {"ce", "focal", "cb_focal"}
+    _VALID_LOSSES = {"ce", "focal", "cb_focal", "arcface"}
 
     def __init__(
         self,
@@ -993,6 +1001,9 @@ class v8ClassificationLoss:
         label_smoothing: float = 0.0,
         focal_gamma: float = 2.0,
         cb_beta: float = 0.9999,
+        arcface_margin: float = 0.5,
+        arcface_scale: float = 30.0,
+        fc_weight: torch.nn.Parameter | None = None,
     ):
         if cls_loss not in self._VALID_LOSSES:
             raise ValueError(
@@ -1002,6 +1013,11 @@ class v8ClassificationLoss:
         self.label_smoothing = label_smoothing
         self.focal_gamma = focal_gamma
         self.cb_beta = cb_beta
+
+        # ArcFace parameters
+        self.arcface_margin = arcface_margin
+        self.arcface_scale = arcface_scale
+        self._fc_weight = fc_weight  # live reference to nn.Linear.weight (nc, feat_dim)
 
         # --- Build per-class weight tensor ---------------------------------------------------
         # Start from user-defined importance weights (or None)
@@ -1036,8 +1052,21 @@ class v8ClassificationLoss:
     # ---------------------------------------------------------------------- forward
     def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
         """Compute the classification loss between predictions and true labels."""
-        preds = preds[1] if isinstance(preds, (list, tuple)) else preds
         targets = batch["cls"]
+
+        if self.cls_loss == "arcface":
+            if isinstance(preds, (list, tuple)):
+                # Eval mode: Classify head returns (probs, logits).
+                # Use standard CE on logits for the validation loss tracker.
+                logits = preds[1]
+                weight = self._ensure_weight_device(logits.device)
+                loss = F.cross_entropy(logits, targets, weight=weight, reduction="mean")
+                return loss, loss.detach()
+            # Training mode: Classify head returns raw features (B, D).
+            return self._arcface_loss(preds, targets)
+
+        # For all other losses, preds is logits (training) or (probs, logits) (inference)
+        preds = preds[1] if isinstance(preds, (list, tuple)) else preds
         weight = self._ensure_weight_device(preds.device)
 
         if self.cls_loss == "ce":
@@ -1086,6 +1115,50 @@ class v8ClassificationLoss:
             loss = loss * class_w
 
         return loss.mean()
+
+    # ---------------------------------------------------------------------- ArcFace loss
+    def _arcface_loss(self, features: torch.Tensor, targets: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+        """ArcFace additive angular margin loss (Deng et al., 2019).
+
+        Computes: L = CE(s * (cos(θ + m) for target, cos(θ) for others), targets)
+        where θ is the angle between L2-normalised features and L2-normalised class weights,
+        m is the angular margin, and s is the scale factor.
+
+        Args:
+            features: Raw features from the Classify head, shape (B, D).
+            targets: Ground-truth class indices, shape (B,).
+
+        Returns:
+            Tuple of (loss, loss_detached).
+        """
+        assert self._fc_weight is not None, "ArcFace loss requires fc_weight (set via init_criterion)."
+
+        # L2-normalise features and weight vectors
+        feat_norm = F.normalize(features, dim=1)  # (B, D)
+        w_norm = F.normalize(self._fc_weight, dim=1)  # (nc, D)
+
+        # Cosine similarity → cos(θ)
+        cos_theta = feat_norm @ w_norm.T  # (B, nc)
+        cos_theta = cos_theta.clamp(-1.0 + 1e-7, 1.0 - 1e-7)  # numerical stability for acos
+
+        # Angle θ
+        theta = torch.acos(cos_theta)  # (B, nc)
+
+        # Add margin to the target class: cos(θ_y + m)
+        nc = cos_theta.shape[1]
+        one_hot = F.one_hot(targets, num_classes=nc).float()  # (B, nc)
+        arcface_logits = torch.cos(theta + self.arcface_margin * one_hot)  # (B, nc)
+
+        # Re-scale
+        arcface_logits = self.arcface_scale * arcface_logits  # (B, nc)
+
+        # Apply per-class importance weights if provided
+        weight = self._ensure_weight_device(features.device)
+
+        loss = F.cross_entropy(
+            arcface_logits, targets, weight=weight, reduction="mean", label_smoothing=self.label_smoothing
+        )
+        return loss, loss.detach()
 
 
 class v8OBBLoss(v8DetectionLoss):

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1039,7 +1039,7 @@ class v8ClassificationLoss:
             if present_mask.any():
                 effective_num = 1.0 - self.cb_beta ** counts[present_mask]
                 w = (1.0 - self.cb_beta) / effective_num
-                w = w / w.sum() * present_mask.sum().float()  # normalise over present classes (mean ≈ 1)
+                w = w / w.sum() * present_mask.sum().float()  # normalize over present classes (mean ≈ 1)
                 cb_weights[present_mask] = w
 
             if importance is not None:

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -964,13 +964,128 @@ class PoseLoss26(v8PoseLoss):
 
 
 class v8ClassificationLoss:
-    """Criterion class for computing training losses for classification."""
+    """Criterion class for computing training losses for classification.
 
+    Supports multiple loss types selectable via ``cls_loss``:
+        - ``'ce'`` – standard (optionally weighted) cross-entropy with optional label smoothing.
+        - ``'focal'`` – focal loss that down-weights easy examples; optionally combined with
+          user-defined ``class_weights``.
+        - ``'cb_focal'`` – class-balanced focal loss (Cui et al., 2019) that auto-computes
+          effective-number-of-samples weights from ``class_counts`` and multiplies them with
+          user-defined ``class_weights`` when provided.
+
+    Args:
+        cls_loss (str): Loss type identifier (``'ce'``, ``'focal'``, or ``'cb_focal'``).
+        class_weights (list[float] | None): Per-class importance weights (length = nc).
+        class_counts (list[int] | None): Per-class sample counts from training set (length = nc).
+        label_smoothing (float): Label-smoothing factor in ``[0, 1]``.
+        focal_gamma (float): Focal-loss focusing parameter γ.
+        cb_beta (float): Class-balanced effective-number β in ``[0, 1)``.
+    """
+
+    _VALID_LOSSES = {"ce", "focal", "cb_focal"}
+
+    def __init__(
+        self,
+        cls_loss: str = "ce",
+        class_weights: list[float] | None = None,
+        class_counts: list[int] | None = None,
+        label_smoothing: float = 0.0,
+        focal_gamma: float = 2.0,
+        cb_beta: float = 0.9999,
+    ):
+        if cls_loss not in self._VALID_LOSSES:
+            raise ValueError(
+                f"Invalid cls_loss='{cls_loss}'. Must be one of {sorted(self._VALID_LOSSES)}."
+            )
+        self.cls_loss = cls_loss
+        self.label_smoothing = label_smoothing
+        self.focal_gamma = focal_gamma
+        self.cb_beta = cb_beta
+
+        # --- Build per-class weight tensor ---------------------------------------------------
+        # Start from user-defined importance weights (or None)
+        self._weight: torch.Tensor | None = None
+        importance = torch.tensor(class_weights, dtype=torch.float32) if class_weights is not None else None
+
+        if cls_loss == "cb_focal" and class_counts is not None:
+            # Effective-number weighting: w_c = (1 - β) / (1 - β^n_c)
+            counts = torch.tensor(class_counts, dtype=torch.float32)
+            effective_num = 1.0 - self.cb_beta ** counts
+            cb_weights = (1.0 - self.cb_beta) / effective_num
+            cb_weights = cb_weights / cb_weights.sum() * len(cb_weights)  # normalise so mean ≈ 1
+            if importance is not None:
+                cb_weights = cb_weights * importance  # combine with user importance
+            self._weight = cb_weights
+        elif importance is not None:
+            self._weight = importance
+
+        # Cache device placement flag
+        self._weight_device: torch.device | None = None
+
+    # ---------------------------------------------------------------------- helpers
+    def _ensure_weight_device(self, device: torch.device) -> torch.Tensor | None:
+        """Move the weight tensor to the correct device (once)."""
+        if self._weight is None:
+            return None
+        if self._weight_device != device:
+            self._weight = self._weight.to(device)
+            self._weight_device = device
+        return self._weight
+
+    # ---------------------------------------------------------------------- forward
     def __call__(self, preds: Any, batch: dict[str, torch.Tensor]) -> tuple[torch.Tensor, torch.Tensor]:
         """Compute the classification loss between predictions and true labels."""
         preds = preds[1] if isinstance(preds, (list, tuple)) else preds
-        loss = F.cross_entropy(preds, batch["cls"], reduction="mean")
+        targets = batch["cls"]
+        weight = self._ensure_weight_device(preds.device)
+
+        if self.cls_loss == "ce":
+            loss = F.cross_entropy(
+                preds, targets, weight=weight, reduction="mean", label_smoothing=self.label_smoothing
+            )
+        elif self.cls_loss in ("focal", "cb_focal"):
+            loss = self._focal_loss(preds, targets, weight)
+        else:
+            # Fallback – should not happen due to __init__ validation
+            loss = F.cross_entropy(preds, targets, reduction="mean")
+
         return loss, loss.detach()
+
+    # ---------------------------------------------------------------------- focal loss
+    def _focal_loss(
+        self, preds: torch.Tensor, targets: torch.Tensor, weight: torch.Tensor | None
+    ) -> torch.Tensor:
+        """Multi-class focal loss with optional per-class weights and label smoothing.
+
+        Implements: FL(p_t) = -α_t * (1 - p_t)^γ * log(p_t)
+        where p_t is the model's estimated probability for the correct class.
+        """
+        nc = preds.shape[1]
+        # Softmax probabilities
+        log_probs = F.log_softmax(preds, dim=1)  # (B, C)
+        probs = log_probs.exp()  # (B, C)
+
+        # One-hot with optional label smoothing
+        if self.label_smoothing > 0:
+            one_hot = torch.full_like(probs, self.label_smoothing / (nc - 1))
+            one_hot.scatter_(1, targets.unsqueeze(1), 1.0 - self.label_smoothing)
+        else:
+            one_hot = torch.zeros_like(probs)
+            one_hot.scatter_(1, targets.unsqueeze(1), 1.0)
+
+        # Focal modulating factor: (1 - p_t)^gamma applied per-class
+        focal_weight = (1.0 - probs).pow(self.focal_gamma)  # (B, C)
+
+        # Per-sample focal cross-entropy: sum over classes of -α * (1-p)^γ * y * log(p)
+        loss = -(focal_weight * one_hot * log_probs).sum(dim=1)  # (B,)
+
+        # Apply per-class weight via the target class
+        if weight is not None:
+            class_w = weight[targets]  # (B,)
+            loss = loss * class_w
+
+        return loss.mean()
 
 
 class v8OBBLoss(v8DetectionLoss):

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -9,6 +9,7 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from ultralytics.utils import LOGGER
 from ultralytics.utils.metrics import OKS_SIGMA, RLE_WEIGHT
 from ultralytics.utils.ops import crop_mask, xywh2xyxy, xyxy2xywh
 from ultralytics.utils.tal import RotatedTaskAlignedAssigner, TaskAlignedAssigner, dist2bbox, dist2rbox, make_anchors
@@ -1012,6 +1013,11 @@ class v8ClassificationLoss:
         self.cls_loss = cls_loss
         self.label_smoothing = label_smoothing
         self.focal_gamma = focal_gamma
+
+        # cb_beta must be in [0, 1); beta=1.0 makes effective_num = 0 → division by zero.
+        if cb_beta >= 1.0:
+            LOGGER.warning(f"cb_beta={cb_beta} >= 1.0 causes division by zero; clamping to 0.9999.")
+            cb_beta = 0.9999
         self.cb_beta = cb_beta
 
         # ArcFace parameters
@@ -1027,9 +1033,17 @@ class v8ClassificationLoss:
         if cls_loss == "cb_focal" and class_counts is not None:
             # Effective-number weighting: w_c = (1 - β) / (1 - β^n_c)
             counts = torch.tensor(class_counts, dtype=torch.float32)
-            effective_num = 1.0 - self.cb_beta ** counts
-            cb_weights = (1.0 - self.cb_beta) / effective_num
-            cb_weights = cb_weights / cb_weights.sum() * len(cb_weights)  # normalise so mean ≈ 1
+            present_mask = counts > 0  # classes with training samples
+
+            # Compute CB weights only for present classes to avoid division by zero
+            # (β^0 = 1 → effective_num = 0).  Absent classes get weight 0.
+            cb_weights = torch.zeros_like(counts)
+            if present_mask.any():
+                effective_num = 1.0 - self.cb_beta ** counts[present_mask]
+                w = (1.0 - self.cb_beta) / effective_num
+                w = w / w.sum() * present_mask.sum().float()  # normalise over present classes (mean ≈ 1)
+                cb_weights[present_mask] = w
+
             if importance is not None:
                 cb_weights = cb_weights * importance  # combine with user importance
             self._weight = cb_weights

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -987,8 +987,8 @@ class v8ClassificationLoss:
         cb_beta (float): Class-balanced effective-number β in ``[0, 1)``.
         arcface_margin (float): ArcFace additive angular margin *m* in radians.
         arcface_scale (float): ArcFace logit re-scaling factor *s*.
-        fc_weight (torch.nn.Parameter | None): Reference to the Classify head's ``linear.weight``
-            parameter (shape ``(nc, feat_dim)``). Required when ``cls_loss='arcface'``.
+        fc_weight (torch.nn.Parameter | None): Reference to the Classify head's ``linear.weight`` parameter (shape
+            ``(nc, feat_dim)``). Required when ``cls_loss='arcface'``.
     """
 
     _VALID_LOSSES = {"ce", "focal", "cb_focal", "arcface"}
@@ -1006,9 +1006,7 @@ class v8ClassificationLoss:
         fc_weight: torch.nn.Parameter | None = None,
     ):
         if cls_loss not in self._VALID_LOSSES:
-            raise ValueError(
-                f"Invalid cls_loss='{cls_loss}'. Must be one of {sorted(self._VALID_LOSSES)}."
-            )
+            raise ValueError(f"Invalid cls_loss='{cls_loss}'. Must be one of {sorted(self._VALID_LOSSES)}.")
         self.cls_loss = cls_loss
         self.label_smoothing = label_smoothing
         self.focal_gamma = focal_gamma
@@ -1027,9 +1025,9 @@ class v8ClassificationLoss:
         if cls_loss == "cb_focal" and class_counts is not None:
             # Effective-number weighting: w_c = (1 - β) / (1 - β^n_c)
             counts = torch.tensor(class_counts, dtype=torch.float32)
-            effective_num = 1.0 - self.cb_beta ** counts
+            effective_num = 1.0 - self.cb_beta**counts
             cb_weights = (1.0 - self.cb_beta) / effective_num
-            cb_weights = cb_weights / cb_weights.sum() * len(cb_weights)  # normalise so mean ≈ 1
+            cb_weights = cb_weights / cb_weights.sum() * len(cb_weights)  # normalize so mean ≈ 1
             if importance is not None:
                 cb_weights = cb_weights * importance  # combine with user importance
             self._weight = cb_weights
@@ -1082,9 +1080,7 @@ class v8ClassificationLoss:
         return loss, loss.detach()
 
     # ---------------------------------------------------------------------- focal loss
-    def _focal_loss(
-        self, preds: torch.Tensor, targets: torch.Tensor, weight: torch.Tensor | None
-    ) -> torch.Tensor:
+    def _focal_loss(self, preds: torch.Tensor, targets: torch.Tensor, weight: torch.Tensor | None) -> torch.Tensor:
         """Multi-class focal loss with optional per-class weights and label smoothing.
 
         Implements: FL(p_t) = -α_t * (1 - p_t)^γ * log(p_t)

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1082,11 +1082,13 @@ class v8ClassificationLoss:
             )
 
         # Manual label-smoothing for torch < 1.10
+        # Matches PyTorch semantics: target = (1 - ε) * one_hot + ε / C
+        #   correct class  → (1 - ε) + ε/C
+        #   other classes   → ε/C
         nc = logits.shape[1]
         log_probs = F.log_softmax(logits, dim=1)  # (B, C)
-        # Smoothed target distribution: (1 - ε) on correct class, ε/(C-1) elsewhere
-        smooth = torch.full_like(log_probs, self.label_smoothing / (nc - 1))
-        smooth.scatter_(1, targets.unsqueeze(1), 1.0 - self.label_smoothing)
+        smooth = torch.full_like(log_probs, self.label_smoothing / nc)
+        smooth.scatter_(1, targets.unsqueeze(1), 1.0 - self.label_smoothing + self.label_smoothing / nc)
         # Per-sample loss
         loss = -(smooth * log_probs).sum(dim=1)  # (B,)
         if weight is not None:
@@ -1135,10 +1137,10 @@ class v8ClassificationLoss:
         log_probs = F.log_softmax(preds, dim=1)  # (B, C)
         probs = log_probs.exp()  # (B, C)
 
-        # One-hot with optional label smoothing
+        # One-hot with optional label smoothing (PyTorch semantics: ε/C everywhere, 1-ε+ε/C on target)
         if self.label_smoothing > 0:
-            one_hot = torch.full_like(probs, self.label_smoothing / (nc - 1))
-            one_hot.scatter_(1, targets.unsqueeze(1), 1.0 - self.label_smoothing)
+            one_hot = torch.full_like(probs, self.label_smoothing / nc)
+            one_hot.scatter_(1, targets.unsqueeze(1), 1.0 - self.label_smoothing + self.label_smoothing / nc)
         else:
             one_hot = torch.zeros_like(probs)
             one_hot.scatter_(1, targets.unsqueeze(1), 1.0)


### PR DESCRIPTION
## Classification Loss Enhancements

### What
Added configurable classification loss types beyond the default cross-entropy, enabling better handling of class imbalance and stronger inter-class separation. Supported losses:

- **Weighted Cross-Entropy** — user-defined per-class importance weights
- **Label Smoothing** — regularization to prevent overconfident predictions (combinable with any loss)
- **Focal Loss** — down-weights easy examples, focuses on hard ones
- **Class-Balanced Focal Loss** — auto-computes effective-number-of-samples weights from training data
- **ArcFace Loss** — additive angular margin loss for highly discriminative feature embeddings

All options are backward compatible — default behavior is unchanged (plain cross-entropy).

### How to Use

# Weighted CE — boost "Reject" class
yolo classify train model=yolo11n-cls.pt data=my_data cls_loss=ce class_weights="{Reject: 10.0}"

# Focal loss
yolo classify train model=yolo11n-cls.pt data=my_data cls_loss=focal focal_gamma=2.0

# Class-balanced focal (auto frequency weights)
yolo classify train model=yolo11n-cls.pt data=my_data cls_loss=cb_focal cb_beta=0.999

# ArcFace with angular margin
yolo classify train model=yolo11n-cls.pt data=my_data cls_loss=arcface arcface_margin=0.5 arcface_scale=30.0

# Combine: ArcFace + class weights + label smoothing
yolo classify train model=yolo11n-cls.pt data=my_data cls_loss=arcface class_weights="{Reject: 10.0}" label_smoothing=0.1


### Config Parameters (default.yaml)

Parameter | Default | Description
-- | -- | --
cls_loss | ce | Loss type: ce, focal, cb_focal, arcface
class_weights | None | Dict or list of per-class importance weights
label_smoothing | 0.0 | Label smoothing factor (works with any loss)
focal_gamma | 2.0 | Focal loss focusing parameter γ
cb_beta | 0.9999 | Class-balanced effective-number β
arcface_margin | 0.5 | ArcFace angular margin (radians)
arcface_scale | 30.0 | ArcFace logit scale factor

### File Changes

File | Change
-- | --
ultralytics/cfg/default.yaml | Added cls_loss, label_smoothing, focal_gamma, cb_beta, arcface_margin, arcface_scale parameters
ultralytics/cfg/__init__.py | Registered new params in CFG_FLOAT_KEYS, CFG_FRACTION_KEYS, and allowed_custom_keys for validation
ultralytics/utils/loss.py | Refactored v8ClassificationLoss to support all 5 loss types with _focal_loss() and _arcface_loss() methods
ultralytics/nn/modules/head.py | Added _return_features flag to Classify head — returns raw features (instead of logits) during training when ArcFace is active
ultralytics/nn/tasks.py | Updated ClassificationModel.init_criterion() to configure head and loss based on cls_loss, with safe reset of _return_features on loss-type switch
ultralytics/models/yolo/classify/train.py | Added _resolve_class_weights() and _compute_class_counts() to ClassificationTrainer for weight/count resolution from dataset
tests/test_classification_loss.py | 23 unit tests covering all loss types, backward compatibility, ArcFace eval fallback, and model reuse scenarios
scripts/test_classification_loss.py | Demo script comparing 12 loss configurations on a real dataset


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Multiple classification losses supported (CE, Focal, Class‑Balanced Focal, ArcFace) with configurable label smoothing, focal gamma, cb_beta, ArcFace margin/scale, and per‑class weighting; ArcFace training/eval integrated.
  * Default configs updated to expose these options; optional Weights & Biases integration enabled.

* **New Tools**
  * Experimental script to run and compare classification-loss training configurations and produce comparative metrics.

* **Tests**
  * Comprehensive test suite validating loss behaviors, weighting, ArcFace modes, and edge cases.

* **Other**
  * Added /data to ignore list and minor CLI/output formatting tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->