### PR TITLE
Move class_weights_resolved from args to model attribute

### DIFF
--- a/tests/test_class_weights.py
+++ b/tests/test_class_weights.py
@@ -176,12 +176,8 @@ def test_loss_class_weights_tensor():
     # Build a minimal mock model
     model = MagicMock()
     model.parameters.return_value = iter([torch.zeros(1)])  # device = cpu
-    model.args = SimpleNamespace(
-        box=7.5,
-        cls=0.5,
-        dfl=1.5,
-        class_weights_resolved=[1.0, 5.0, 1.0],
-    )
+    model.args = SimpleNamespace(box=7.5, cls=0.5, dfl=1.5)
+    model.class_weights_resolved = [1.0, 5.0, 1.0]
     m = MagicMock()
     m.stride = torch.tensor([8.0, 16.0, 32.0])
     m.nc = 3
@@ -207,6 +203,7 @@ def test_loss_no_class_weights():
     model = MagicMock()
     model.parameters.return_value = iter([torch.zeros(1)])
     model.args = SimpleNamespace(box=7.5, cls=0.5, dfl=1.5)
+    model.class_weights_resolved = None
     m = MagicMock()
     m.stride = torch.tensor([8.0, 16.0, 32.0])
     m.nc = 3
@@ -237,8 +234,8 @@ def test_trainer_resolve_dict():
 
     DetectionTrainer._resolve_class_weights(trainer)
 
-    assert trainer.args.class_weights_resolved == [2.0, 1.0, 5.0]
-    print(f"  Resolved: {trainer.args.class_weights_resolved}")
+    assert trainer.model.class_weights_resolved == [2.0, 1.0, 5.0]
+    print(f"  Resolved: {trainer.model.class_weights_resolved}")
     print("  ✓ Dict resolve OK")
 
 
@@ -256,7 +253,7 @@ def test_trainer_resolve_list():
 
     DetectionTrainer._resolve_class_weights(trainer)
 
-    assert trainer.args.class_weights_resolved == [2.0, 1.0, 5.0]
+    assert trainer.model.class_weights_resolved == [2.0, 1.0, 5.0]
     print("  ✓ List resolve OK")
 
 
@@ -274,7 +271,7 @@ def test_trainer_resolve_none():
 
     DetectionTrainer._resolve_class_weights(trainer)
 
-    assert trainer.args.class_weights_resolved is None
+    assert trainer.model.class_weights_resolved is None
     print("  ✓ None resolve OK")
 
 
@@ -296,7 +293,7 @@ def test_trainer_resolve_missing_class_warns():
         DetectionTrainer._resolve_class_weights(trainer)
         mock_logger.warning.assert_called_once()
 
-    assert trainer.args.class_weights_resolved == [2.0, 1.0]  # unicorn ignored, dog defaults to 1.0
+    assert trainer.model.class_weights_resolved == [2.0, 1.0]  # unicorn ignored, dog defaults to 1.0
     print("  ✓ Unknown class warning OK")
 
 

--- a/tests/test_classification_loss.py
+++ b/tests/test_classification_loss.py
@@ -244,8 +244,8 @@ def test_resolve_class_weights_dict():
 
     trainer._resolve_class_weights()
 
-    assert trainer.args.class_weights_resolved == [3.0, 1.0, 5.0], f"Got {trainer.args.class_weights_resolved}"
-    print(f"[PASS] resolve_class_weights dict: {trainer.args.class_weights_resolved}")
+    assert trainer.model.class_weights_resolved == [3.0, 1.0, 5.0], f"Got {trainer.model.class_weights_resolved}"
+    print(f"[PASS] resolve_class_weights dict: {trainer.model.class_weights_resolved}")
 
 
 # ──────────────────────────────────────── 13. Resolve class_weights list ─────
@@ -260,8 +260,8 @@ def test_resolve_class_weights_list():
 
     trainer._resolve_class_weights()
 
-    assert trainer.args.class_weights_resolved == [2.0, 3.0, 1.0]
-    print(f"[PASS] resolve_class_weights list: {trainer.args.class_weights_resolved}")
+    assert trainer.model.class_weights_resolved == [2.0, 3.0, 1.0]
+    print(f"[PASS] resolve_class_weights list: {trainer.model.class_weights_resolved}")
 
 
 # ──────────────────────────────────────── 14. Resolve — no class_weights ─────
@@ -276,7 +276,7 @@ def test_resolve_class_weights_none():
 
     trainer._resolve_class_weights()
 
-    assert trainer.args.class_weights_resolved is None
+    assert trainer.model.class_weights_resolved is None
     print("[PASS] resolve_class_weights None -> None")
 
 

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -484,7 +484,7 @@ class BaseTrainer:
 
             self.run_callbacks("on_train_epoch_end")
             if RANK in {-1, 0}:
-                self.ema.update_attr(self.model, include=["yaml", "nc", "args", "names", "stride", "class_weights"])
+                self.ema.update_attr(self.model, include=["yaml", "nc", "args", "names", "stride", "class_weights", "class_weights_resolved"])
 
             # Validation
             final_epoch = epoch + 1 >= self.epochs
@@ -946,6 +946,7 @@ class BaseTrainer:
                     ckpt_args["data"] = self.args.data
 
                 resume = True
+                ckpt_args.pop("class_weights_resolved", None)  # derived value, not a valid config key
                 self.args = get_cfg(ckpt_args)
                 self.args.model = self.args.resume = str(last)  # reinstate model
                 for k in (

--- a/ultralytics/models/yolo/classify/train.py
+++ b/ultralytics/models/yolo/classify/train.py
@@ -86,7 +86,7 @@ class ClassificationTrainer(BaseTrainer):
         names = self.data["names"]  # {0: 'cat', 1: 'dog', ...}
 
         if not raw:
-            self.args.class_weights_resolved = None
+            self.model.class_weights_resolved = None
             return
 
         resolved = [1.0] * nc
@@ -104,7 +104,7 @@ class ClassificationTrainer(BaseTrainer):
         else:
             raise TypeError(f"Unsupported class_weights type: {type(raw)}. Expected dict or list.")
 
-        self.args.class_weights_resolved = resolved
+        self.model.class_weights_resolved = resolved
         LOGGER.info(f"Classification class weights resolved: {dict(zip(names.values(), resolved))}")
 
     def _compute_class_counts(self):

--- a/ultralytics/models/yolo/detect/train.py
+++ b/ultralytics/models/yolo/detect/train.py
@@ -156,11 +156,11 @@ class DetectionTrainer(BaseTrainer):
 
         Accepts either a dict mapping class names to weights (e.g. {"cone": 5.0}) or a list of floats (one per class).
         Classes not specified in a dict default to weight 1.0. The resolved list is stored in
-        ``self.args.class_weights_resolved`` and also logged for visibility.
+        ``self.model.class_weights_resolved`` and also logged for visibility.
         """
         raw = getattr(self.args, "class_weights", None)
         if not raw:
-            self.args.class_weights_resolved = None
+            self.model.class_weights_resolved = None
             return
 
         nc = self.data["nc"]
@@ -191,7 +191,7 @@ class DetectionTrainer(BaseTrainer):
                 f"Example: class_weights={{cone: 5.0, person: 1.0}} or class_weights=[1.0, 5.0, 1.0]"
             )
 
-        self.args.class_weights_resolved = resolved
+        self.model.class_weights_resolved = resolved
         # Log resolved weights
         weight_str = ", ".join(f"{names[i]}: {resolved[i]}" for i in range(nc))
         LOGGER.info(f"Class weights resolved: {{{weight_str}}}")
@@ -215,8 +215,10 @@ class DetectionTrainer(BaseTrainer):
     def get_validator(self):
         """Return a DetectionValidator for YOLO model validation."""
         self.loss_names = "box_loss", "cls_loss", "dfl_loss"
+        args = copy(self.args)
+        args.class_weights_resolved = getattr(self.model, "class_weights_resolved", None)
         return yolo.detect.DetectionValidator(
-            self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
+            self.test_loader, save_dir=self.save_dir, args=args, _callbacks=self.callbacks
         )
 
     def label_loss_items(self, loss_items: list[float] | None = None, prefix: str = "train"):

--- a/ultralytics/models/yolo/obb/train.py
+++ b/ultralytics/models/yolo/obb/train.py
@@ -74,6 +74,8 @@ class OBBTrainer(yolo.detect.DetectionTrainer):
     def get_validator(self):
         """Return an instance of OBBValidator for validation of YOLO model."""
         self.loss_names = "box_loss", "cls_loss", "dfl_loss", "angle_loss"
+        args = copy(self.args)
+        args.class_weights_resolved = getattr(self.model, "class_weights_resolved", None)
         return yolo.obb.OBBValidator(
-            self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
+            self.test_loader, save_dir=self.save_dir, args=args, _callbacks=self.callbacks
         )

--- a/ultralytics/models/yolo/pose/train.py
+++ b/ultralytics/models/yolo/pose/train.py
@@ -94,8 +94,10 @@ class PoseTrainer(yolo.detect.DetectionTrainer):
         self.loss_names = "box_loss", "pose_loss", "kobj_loss", "cls_loss", "dfl_loss"
         if getattr(unwrap_model(self.model).model[-1], "flow_model", None) is not None:
             self.loss_names += ("rle_loss",)
+        args = copy(self.args)
+        args.class_weights_resolved = getattr(self.model, "class_weights_resolved", None)
         return yolo.pose.PoseValidator(
-            self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
+            self.test_loader, save_dir=self.save_dir, args=args, _callbacks=self.callbacks
         )
 
     def get_dataset(self) -> dict[str, Any]:

--- a/ultralytics/models/yolo/segment/train.py
+++ b/ultralytics/models/yolo/segment/train.py
@@ -64,6 +64,8 @@ class SegmentationTrainer(yolo.detect.DetectionTrainer):
     def get_validator(self):
         """Return an instance of SegmentationValidator for validation of YOLO model."""
         self.loss_names = "box_loss", "seg_loss", "cls_loss", "dfl_loss", "sem_loss"
+        args = copy(self.args)
+        args.class_weights_resolved = getattr(self.model, "class_weights_resolved", None)
         return yolo.segment.SegmentationValidator(
-            self.test_loader, save_dir=self.save_dir, args=copy(self.args), _callbacks=self.callbacks
+            self.test_loader, save_dir=self.save_dir, args=args, _callbacks=self.callbacks
         )

--- a/ultralytics/nn/tasks.py
+++ b/ultralytics/nn/tasks.py
@@ -740,7 +740,7 @@ class ClassificationModel(BaseModel):
 
         return v8ClassificationLoss(
             cls_loss=cls_loss,
-            class_weights=getattr(args, "class_weights_resolved", None),
+            class_weights=getattr(self, "class_weights_resolved", None),
             class_counts=getattr(args, "class_counts", None),
             label_smoothing=getattr(args, "label_smoothing", 0.0),
             focal_gamma=getattr(args, "focal_gamma", 2.0),

--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -362,7 +362,7 @@ class v8DetectionLoss:
         self.proj = torch.arange(m.reg_max, dtype=torch.float, device=device)
 
         # Per-class loss weights for box/DFL loss (reduces FN for important classes)
-        cw = getattr(h, "class_weights_resolved", None)
+        cw = getattr(model, "class_weights_resolved", None)
         if cw is not None:
             self.class_weights = torch.tensor(cw, dtype=torch.float, device=device)  # (nc,)
         else:


### PR DESCRIPTION
Store the resolved class weights on the model object instead of the args namespace to avoid polluting config with derived runtime values. This prevents issues when resuming from checkpoints (where args are restored via get_cfg) and keeps the separation between user config and computed state clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal restructuring: Class weights resolution is now stored on the model object instead of trainer arguments, ensuring consistency across detection, classification, segmentation, pose, and OBB trainers.

* **Tests**
  * Updated test assertions to validate class weights resolution on the model object.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->