### PR TITLE
Fix class_counts validation error in ClassificationValidator

### DIFF
--- a/ultralytics/cfg/__init__.py
+++ b/ultralytics/cfg/__init__.py
@@ -311,7 +311,7 @@ def get_cfg(
     # Merge overrides
     if overrides:
         overrides = cfg2dict(overrides)
-        check_dict_alignment(cfg, overrides)
+        check_dict_alignment(cfg, overrides, allowed_custom_keys={"class_counts", "class_weights_resolved"})
         cfg = {**cfg, **overrides}  # merge cfg and overrides dicts (prefer overrides)
 
     # Special handling for numeric project/name


### PR DESCRIPTION
**Bug:** `_compute_class_counts()` unconditionally writes `self.args.class_counts = None` for all non-cb_focal loss types
  (including ce and arcface). During `_setup_train()`, the trainer passes `self.args` to `ClassificationValidator`, which
  calls `get_cfg(overrides=args)`. This triggers check_dict_alignment against DEFAULT_CFG, which rejects class_counts as
  an unknown key — crashing before the first epoch for any classification run using the new loss functions.

**Fix:** Pass `allowed_custom_keys={"class_counts", "class_weights_resolved"}` at the get_cfg call site
  (`cfg/__init__.py:314`). These are internal runtime keys computed by `set_model_attributes()` — not user-facing config —
  so they are whitelisted only at this one call site rather than widening the global default, keeping CLI and settings
  parsing unaffected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation now properly accepts additional custom fields in override parameters, preventing validation errors for expanded configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->