### PR TITLE
Fix AMP dtype mismatch in v8ClassificationLoss weight tensor

### DIFF
--- a/ultralytics/utils/loss.py
+++ b/ultralytics/utils/loss.py
@@ -1052,12 +1052,13 @@ class v8ClassificationLoss:
         self._weight_device: torch.device | None = None
 
     # ---------------------------------------------------------------------- helpers
-    def _ensure_weight_device(self, device: torch.device) -> torch.Tensor | None:
-        """Move the weight tensor to the correct device (once)."""
+    def _ensure_weight_device(self, device: torch.device, dtype: torch.dtype | None = None) -> torch.Tensor | None:
+        """Move the weight tensor to the correct device and dtype (once)."""
         if self._weight is None:
             return None
-        if self._weight_device != device:
-            self._weight = self._weight.to(device)
+        target_dtype = dtype or self._weight.dtype
+        if self._weight_device != device or self._weight.dtype != target_dtype:
+            self._weight = self._weight.to(device=device, dtype=target_dtype)
             self._weight_device = device
         return self._weight
 
@@ -1105,7 +1106,7 @@ class v8ClassificationLoss:
                 # Eval mode: Classify head returns (probs, logits).
                 # Use standard CE on logits for the validation loss tracker.
                 logits = preds[1]
-                weight = self._ensure_weight_device(logits.device)
+                weight = self._ensure_weight_device(logits.device, logits.dtype)
                 loss = F.cross_entropy(logits, targets, weight=weight, reduction="mean")
                 return loss, loss.detach()
             # Training mode: Classify head returns raw features (B, D).
@@ -1113,7 +1114,7 @@ class v8ClassificationLoss:
 
         # For all other losses, preds is logits (training) or (probs, logits) (inference)
         preds = preds[1] if isinstance(preds, (list, tuple)) else preds
-        weight = self._ensure_weight_device(preds.device)
+        weight = self._ensure_weight_device(preds.device, preds.dtype)
 
         if self.cls_loss == "ce":
             loss = self._cross_entropy_with_smoothing(preds, targets, weight)


### PR DESCRIPTION
Bug: _ensure_weight_device only moved the class-weight tensor to the correct device but never cast its dtype. Under
  AMP the model runs in float16, but self._weight was always created as float32. This caused a RuntimeError: expected
  scalar type Half but found Float when F.cross_entropy received mismatched dtypes for logits and weight — crashing at
  the first validation step of any run using class_weights.

  Fix: Added an optional dtype parameter to _ensure_weight_device. The tensor is now recast whenever either the device
  or dtype diverges from the target. Both call sites pass the logits/preds dtype so the weight automatically follows the
   model's precision. No behaviour change when AMP is disabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced weight tensor handling in classification loss calculations to properly align data types with input predictions and logits, improving model training stability and compatibility across different precision configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->