### PR TITLE
Add Dice and Boundary IoU (BIoU) as segmentation evaluation metrics

### DIFF
--- a/tests/test_boundary_metrics.py
+++ b/tests/test_boundary_metrics.py
@@ -247,5 +247,26 @@ def test_matched_mask_quality_below_threshold_no_pairs():
     assert cls.size == 0
 
 
+def test_segment_metrics_class_result_includes_boundary():
+    """`class_result` returns a tuple of 10 values (4 box + 4 mask + Dice + BIoU), no TypeError."""
+    sm = _build_segment_metrics(nc=2)
+    sm.dice_per_class = np.array([0.8, 0.6])
+    sm.biou_per_class = np.array([0.7, 0.5])
+    # Seed the underlying Metric objects so class_result(0) doesn't IndexError.
+    # ap50 / ap are properties derived from all_ap (nc, 10), so seed that directly.
+    for metric in (sm.box, sm.seg):
+        metric.p = [0.9, 0.85]
+        metric.r = [0.8, 0.75]
+        metric.all_ap = np.ones((2, 10)) * 0.7
+        metric.ap_class_index = [0, 1]
+
+    result = sm.class_result(0)
+
+    # 4 box + 4 mask + 2 boundary = 10 values (tuple, matching Metric.class_result return type)
+    assert len(result) == 10
+    assert result[-2] == pytest.approx(0.8)  # Dice for class 0
+    assert result[-1] == pytest.approx(0.7)  # BIoU for class 0
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/tests/test_boundary_metrics.py
+++ b/tests/test_boundary_metrics.py
@@ -1,0 +1,251 @@
+"""Tests for Dice and Boundary-IoU metric helpers and SegmentMetrics integration.
+
+Covers:
+  1. mask_dice / mask_biou degenerate cases (identical masks → 1, disjoint masks → 0).
+  2. mask_boundary_rim shape and emptiness rules.
+  3. SegmentMetrics aggregates per-class Dice / BIoU from matched-pair stats.
+  4. SegmentMetrics.keys / mean_results / class_result widen consistently.
+  5. fitness_weight length 10 routes the last two weights into Dice / BIoU contributions.
+  6. End-to-end: SegmentationValidator._matched_mask_quality picks the correct pairs and
+     reports Dice == 1.0 / BIoU == 1.0 when pred == GT.
+
+Run all:
+    pytest tests/test_boundary_metrics.py -v -s
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+import torch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from ultralytics.utils.metrics import (
+    SegmentMetrics,
+    mask_biou,
+    mask_boundary_rim,
+    mask_dice,
+)
+
+
+def _circle(size: int = 64, cy: int = 32, cx: int = 32, r: int = 16) -> torch.Tensor:
+    """Return a (1, H, W) binary mask with a filled circle."""
+    yy, xx = torch.meshgrid(torch.arange(size), torch.arange(size), indexing="ij")
+    return ((yy - cy) ** 2 + (xx - cx) ** 2 <= r * r).float().unsqueeze(0)
+
+
+# ─────────────────────────────── helpers: mask_dice / mask_biou ───────────────────────────────
+
+
+def test_mask_dice_identical_returns_one():
+    """Dice between identical masks is 1.0 (within float tolerance)."""
+    g = _circle().flatten(1)
+    out = mask_dice(g, g)
+    assert out.shape == (1, 1)
+    assert pytest.approx(out.item(), abs=1e-5) == 1.0
+
+
+def test_mask_dice_disjoint_returns_zero():
+    """Dice between disjoint non-empty masks is 0 (intersection = 0, denom > 0)."""
+    a = _circle(cy=16, cx=16, r=8).flatten(1)
+    b = _circle(cy=48, cx=48, r=8).flatten(1)
+    assert mask_dice(a, b).item() == pytest.approx(0.0, abs=1e-6)
+
+
+def test_mask_dice_matches_iou_relationship():
+    """Sanity check: Dice = 2*IoU / (1+IoU) holds for partially overlapping masks."""
+    a = _circle(cy=32, cx=28, r=14).flatten(1)
+    b = _circle(cy=32, cx=36, r=14).flatten(1)
+    inter = (a * b).sum().item()
+    union = ((a + b) > 0).float().sum().item()
+    iou = inter / union
+    expected = 2 * iou / (1 + iou)
+    assert mask_dice(a, b).item() == pytest.approx(expected, abs=1e-5)
+
+
+def test_mask_boundary_rim_empty_input():
+    """Empty masks produce empty rims."""
+    g = torch.zeros(1, 16, 16)
+    assert mask_boundary_rim(g, kernel=3).sum().item() == 0.0
+
+
+def test_mask_boundary_rim_thickness_grows_with_kernel():
+    """Larger kernel ⇒ thicker rim (more 1-pixels), at least until rim swallows the whole mask."""
+    g = _circle(size=80, r=24)
+    rims = [mask_boundary_rim(g, k).sum().item() for k in (3, 5, 9)]
+    assert rims[0] < rims[1] < rims[2]
+
+
+def test_mask_biou_identical_masks_is_one():
+    """BIoU between identical non-trivial masks is exactly 1.0."""
+    g = _circle()
+    assert mask_biou(g, g, kernel=3).item() == pytest.approx(1.0, abs=1e-6)
+
+
+def test_mask_biou_disjoint_masks_is_zero():
+    """Disjoint masks ⇒ rims disjoint ⇒ BIoU = 0."""
+    a = _circle(cy=16, cx=16, r=8)
+    b = _circle(cy=48, cx=48, r=8)
+    assert mask_biou(a, b, kernel=3).item() == pytest.approx(0.0, abs=1e-6)
+
+
+def test_mask_biou_more_sensitive_than_iou_to_shift():
+    """Small offset should drop BIoU faster than mask IoU (the whole point of the metric)."""
+    from ultralytics.utils.metrics import mask_iou
+
+    g = _circle(cy=32, cx=32, r=20)
+    p = _circle(cy=32, cx=34, r=20)  # 2-pixel shift
+    iou_val = mask_iou(g.flatten(1), p.flatten(1)).item()
+    biou_val = mask_biou(g, p, kernel=3).item()
+    assert biou_val < iou_val, f"Expected BIoU ({biou_val:.3f}) < mask IoU ({iou_val:.3f}) under small shift"
+
+
+# ───────────────────────────── SegmentMetrics integration ────────────────────────────────────
+
+
+def _build_segment_metrics(fitness_weight=None, nc=2, boundary_kernel=3):
+    names = {i: f"c{i}" for i in range(nc)}
+    return SegmentMetrics(names=names, fitness_weight=fitness_weight, boundary_kernel=boundary_kernel)
+
+
+def test_segment_metrics_keys_include_dice_biou():
+    """`keys` widens by exactly two entries for Dice and BIoU."""
+    sm = _build_segment_metrics()
+    assert "metrics/dice(M)" in sm.keys
+    assert "metrics/biou(M)" in sm.keys
+    # 4 box + 4 mask + 2 boundary = 10
+    assert len(sm.keys) == 10
+
+
+def test_segment_metrics_mean_results_widens_to_match_keys():
+    """`mean_results()` length must match `len(keys)` so print_results / save_metrics line up."""
+    sm = _build_segment_metrics()
+    assert len(sm.mean_results()) == len(sm.keys)
+
+
+def test_segment_metrics_process_aggregates_per_class():
+    """Per-pair scalars get bucketed by class id and averaged on `process()`.
+
+    We seed `self.stats` with synthetic per-batch arrays for both the base detection stats
+    (so `DetMetrics.process` doesn't crash on empty concatenation) and the new boundary stats,
+    then assert the per-class / mean aggregation matches by-hand averages.
+    """
+    sm = _build_segment_metrics(nc=2)
+    # Base detection stats: three predictions across two classes, all TP at IoU 0.5+.
+    niou = 10  # match _process_batch tp width
+    tp_arr = np.ones((3, niou), dtype=bool)
+    sm.stats["tp"].extend([tp_arr])
+    sm.stats["tp_m"].extend([tp_arr])
+    sm.stats["conf"].extend([np.array([0.9, 0.8, 0.7], dtype=np.float32)])
+    sm.stats["pred_cls"].extend([np.array([0, 0, 1], dtype=np.float32)])
+    sm.stats["target_cls"].extend([np.array([0, 0, 1], dtype=np.float32)])
+    sm.stats["target_img"].extend([np.array([0, 0, 1], dtype=np.float32)])
+    # Boundary stats: two matched pairs for class 0, one for class 1.
+    sm.stats["mask_dice"].extend([np.array([0.8, 0.6], dtype=np.float32), np.array([0.4], dtype=np.float32)])
+    sm.stats["mask_biou"].extend([np.array([0.5, 0.3], dtype=np.float32), np.array([0.9], dtype=np.float32)])
+    sm.stats["matched_cls"].extend([np.array([0, 0], dtype=np.int64), np.array([1], dtype=np.int64)])
+
+    sm.process(save_dir=Path("."), plot=False)
+
+    assert sm.dice_per_class[0] == pytest.approx(0.7)  # mean(0.8, 0.6)
+    assert sm.dice_per_class[1] == pytest.approx(0.4)
+    assert sm.biou_per_class[0] == pytest.approx(0.4)  # mean(0.5, 0.3)
+    assert sm.biou_per_class[1] == pytest.approx(0.9)
+    assert sm.dice_mean == pytest.approx((0.7 + 0.4) / 2)
+    assert sm.biou_mean == pytest.approx((0.4 + 0.9) / 2)
+    # Sanity: keys / mean_results lengths still aligned post-process.
+    assert len(sm.mean_results()) == len(sm.keys)
+
+
+def test_segment_metrics_fitness_weight_length_10_adds_boundary_terms():
+    """fitness_weight = [box×4, mask×4, dice, biou] adds dice/biou contribution to fitness()."""
+    weights = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 3.0]
+    sm = _build_segment_metrics(fitness_weight=weights)
+    assert sm.dice_fitness_weight == 2.0
+    assert sm.biou_fitness_weight == 3.0
+    sm.dice_mean = 0.5
+    sm.biou_mean = 0.25
+    # Box & mask AP metrics are empty/zero so their fitness contributions are 0.
+    assert sm.fitness == pytest.approx(2.0 * 0.5 + 3.0 * 0.25)
+
+
+def test_segment_metrics_fitness_weight_length_8_skips_boundary_terms():
+    """Backward compat: 8-value weights ⇒ dice/biou weights stay at 0 and don't affect fitness."""
+    weights = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8]
+    sm = _build_segment_metrics(fitness_weight=weights)
+    assert sm.dice_fitness_weight == 0.0
+    assert sm.biou_fitness_weight == 0.0
+    sm.dice_mean = 0.5
+    sm.biou_mean = 0.25
+    # Boundary terms must not contribute under the 8-value layout.
+    assert sm.fitness == 0.0
+
+
+# ───────────────────────── SegmentationValidator._matched_mask_quality ───────────────────────
+
+
+def _make_validator_with_metrics(boundary_kernel=3):
+    """Construct a minimal SegmentationValidator-like object exposing only what the helper needs.
+
+    We avoid the full constructor (which requires a dataloader / save_dir) and instead bind the
+    SegmentMetrics instance + the helper method onto a SimpleNamespace.
+    """
+    from ultralytics.models.yolo.segment.val import SegmentationValidator
+
+    metrics = _build_segment_metrics(boundary_kernel=boundary_kernel)
+    # SimpleNamespace gives us attribute access; methods need an explicit self via __get__.
+    ns = SimpleNamespace(metrics=metrics)
+    ns._matched_mask_quality = SegmentationValidator._matched_mask_quality.__get__(ns)
+    return ns
+
+
+def test_matched_mask_quality_identical_masks_score_one():
+    """When pred == GT and classes agree, Dice and BIoU are 1.0 for every matched pair."""
+    val = _make_validator_with_metrics()
+    gt = torch.stack([_circle(cy=20, cx=20, r=8).squeeze(0), _circle(cy=44, cx=44, r=10).squeeze(0)])
+    pred = gt.clone()
+    gt_cls = torch.tensor([0, 1])
+    pred_cls = torch.tensor([0, 1])
+    iou = torch.eye(2)  # perfect IoU diagonal so both pairs match at 0.5
+    dice, biou, cls = val._matched_mask_quality(gt, pred, gt_cls, pred_cls, iou)
+    assert dice.shape == (2,)
+    assert np.allclose(dice, 1.0, atol=1e-5)
+    assert np.allclose(biou, 1.0, atol=1e-5)
+    assert set(cls.tolist()) == {0, 1}
+
+
+def test_matched_mask_quality_class_mismatch_yields_no_pairs():
+    """Class disagreement zeros the IoU matrix ⇒ no pairs reported."""
+    val = _make_validator_with_metrics()
+    gt = _circle().repeat(1, 1, 1)
+    pred = gt.clone()
+    gt_cls = torch.tensor([0])
+    pred_cls = torch.tensor([1])
+    iou = torch.tensor([[1.0]])
+    dice, biou, cls = val._matched_mask_quality(gt, pred, gt_cls, pred_cls, iou)
+    assert dice.size == 0
+    assert biou.size == 0
+    assert cls.size == 0
+
+
+def test_matched_mask_quality_below_threshold_no_pairs():
+    """IoU strictly below 0.5 ⇒ no match, no scores."""
+    val = _make_validator_with_metrics()
+    gt = _circle().repeat(1, 1, 1)
+    pred = gt.clone()
+    gt_cls = torch.tensor([0])
+    pred_cls = torch.tensor([0])
+    iou = torch.tensor([[0.3]])  # below default 0.5
+    dice, biou, cls = val._matched_mask_quality(gt, pred, gt_cls, pred_cls, iou)
+    assert dice.size == 0
+    assert biou.size == 0
+    assert cls.size == 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/tests/test_boundary_metrics.py
+++ b/tests/test_boundary_metrics.py
@@ -131,9 +131,9 @@ def test_segment_metrics_mean_results_widens_to_match_keys():
 def test_segment_metrics_process_aggregates_per_class():
     """Per-pair scalars get bucketed by class id and averaged on `process()`.
 
-    We seed `self.stats` with synthetic per-batch arrays for both the base detection stats
-    (so `DetMetrics.process` doesn't crash on empty concatenation) and the new boundary stats,
-    then assert the per-class / mean aggregation matches by-hand averages.
+    We seed `self.stats` with synthetic per-batch arrays for both the base detection stats (so `DetMetrics.process`
+    doesn't crash on empty concatenation) and the new boundary stats, then assert the per-class / mean aggregation
+    matches by-hand averages.
     """
     sm = _build_segment_metrics(nc=2)
     # Base detection stats: three predictions across two classes, all TP at IoU 0.5+.
@@ -163,7 +163,7 @@ def test_segment_metrics_process_aggregates_per_class():
 
 
 def test_segment_metrics_fitness_weight_length_10_adds_boundary_terms():
-    """fitness_weight = [box×4, mask×4, dice, biou] adds dice/biou contribution to fitness()."""
+    """Fitness_weight = [box×4, mask×4, dice, biou] adds dice/biou contribution to fitness()."""
     weights = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 2.0, 3.0]
     sm = _build_segment_metrics(fitness_weight=weights)
     assert sm.dice_fitness_weight == 2.0
@@ -192,8 +192,8 @@ def test_segment_metrics_fitness_weight_length_8_skips_boundary_terms():
 def _make_validator_with_metrics(boundary_kernel=3):
     """Construct a minimal SegmentationValidator-like object exposing only what the helper needs.
 
-    We avoid the full constructor (which requires a dataloader / save_dir) and instead bind the
-    SegmentMetrics instance + the helper method onto a SimpleNamespace.
+    We avoid the full constructor (which requires a dataloader / save_dir) and instead bind the SegmentMetrics instance
+    + the helper method onto a SimpleNamespace.
     """
     from ultralytics.models.yolo.segment.val import SegmentationValidator
 

--- a/ultralytics/cfg/default.yaml
+++ b/ultralytics/cfg/default.yaml
@@ -39,7 +39,7 @@ freeze: # (int | list, optional) freeze first N layers (int) or specific layer i
 multi_scale: 0.0 # (float) multi-scale range as a fraction of imgsz; sizes are rounded to stride multiples
 compile: False # (bool | str) enable torch.compile() backend='inductor'; True="default", False=off, or "default|reduce-overhead|max-autotune-no-cudagraphs"
 
-fitness_weight: [0.0, 0.9, 0.1, 0.0] # (list[float]) fitness weights for [P, R, mAP@0.5, mAP@0.5:0.95] for detection/OBB/classify tasks, or [box_P, box_R, box_mAP@0.5, box_mAP@0.5:0.95, pose_P, pose_R, pose_mAP@0.5, pose_mAP@0.5:0.95] for pose/segment tasks (4 or 8 values). Can be overridden for custom optimization targets.
+fitness_weight: [0.0, 0.9, 0.1, 0.0] # (list[float]) fitness weights for [P, R, mAP@0.5, mAP@0.5:0.95] for detection/OBB/classify tasks, or [box_P, box_R, box_mAP@0.5, box_mAP@0.5:0.95, pose_P/mask_P, pose_R/mask_R, pose_mAP@0.5/mask_mAP@0.5, pose_mAP@0.5:0.95/mask_mAP@0.5:0.95] for pose/segment tasks (8 values). Segment task additionally accepts 10 values: the 8-value layout followed by [mask_Dice, mask_BIoU] to weight boundary-quality metrics into fitness. Can be overridden for custom optimization targets.
 class_weights: # (dict | list, optional) per-class loss weights to reduce FN for important classes, e.g. {cone: 5.0, person: 1.0}. Dict maps class names to weights; list provides one weight per class. Unspecified classes default to 1.0. Affects box/DFL loss and fitness (best model selection).
 class_weights_resolved: # (list, optional) internally resolved per-class weight list derived from class_weights. Auto-populated by the trainer; not intended for direct user configuration.
 channels: 3 # (int) number of input image channels (1 for grayscale, 3 for RGB, N for multispectral)

--- a/ultralytics/engine/trainer.py
+++ b/ultralytics/engine/trainer.py
@@ -688,8 +688,8 @@ class BaseTrainer:
             log_parts.append("\n--- Total Fitness Calculation:")
             log_parts.append(f"  {box_fitness:.4f} (box) + {pose_fitness:.4f} (pose) = {self.fitness:.4f}")
 
-        elif task == "segment" and len(fitness_weight) == 8:
-            # Segment task with 8 weights
+        elif task == "segment" and len(fitness_weight) in (8, 10):
+            # Segment task with 8 or 10 weights (10 adds Dice + BIoU as boundary-aware terms)
             log_parts.append(f"\n--- Box Detection Metrics (weights: {fitness_weight[:4]}):")
             box_metrics = []
             metric_names_box = ["metrics/precision(B)", "metrics/recall(B)", "metrics/mAP50(B)", "metrics/mAP50-95(B)"]
@@ -703,7 +703,7 @@ class BaseTrainer:
             box_fitness = sum(v * w for v, w in zip(box_vals, fitness_weight[:4]))
             log_parts.append(f"  Box fitness contribution: {box_fitness:.4f}")
 
-            log_parts.append(f"\n--- Mask Segmentation Metrics (weights: {fitness_weight[4:]}):")
+            log_parts.append(f"\n--- Mask Segmentation Metrics (weights: {fitness_weight[4:8]}):")
             mask_metrics = []
             metric_names_mask = ["metrics/precision(M)", "metrics/recall(M)", "metrics/mAP50(M)", "metrics/mAP50-95(M)"]
             for i, name in enumerate(metric_names_mask):
@@ -713,11 +713,24 @@ class BaseTrainer:
 
             # Calculate mask fitness contribution
             mask_vals = [self.metrics.get(name, 0.0) for name in metric_names_mask]
-            mask_fitness = sum(v * w for v, w in zip(mask_vals, fitness_weight[4:]))
+            mask_fitness = sum(v * w for v, w in zip(mask_vals, fitness_weight[4:8]))
             log_parts.append(f"  Mask fitness contribution: {mask_fitness:.4f}")
 
+            boundary_fitness = 0.0
+            if len(fitness_weight) == 10:
+                dice_val = self.metrics.get("metrics/dice(M)", 0.0)
+                biou_val = self.metrics.get("metrics/biou(M)", 0.0)
+                dice_w, biou_w = fitness_weight[8], fitness_weight[9]
+                boundary_fitness = dice_val * dice_w + biou_val * biou_w
+                log_parts.append(f"\n--- Mask Boundary Metrics (weights: [{dice_w}, {biou_w}]):")
+                log_parts.append(f"  metrics/dice(M): {dice_val:.4f} | metrics/biou(M): {biou_val:.4f}")
+                log_parts.append(f"  Boundary fitness contribution: {boundary_fitness:.4f}")
+
             log_parts.append("\n--- Total Fitness Calculation:")
-            log_parts.append(f"  {box_fitness:.4f} (box) + {mask_fitness:.4f} (mask) = {self.fitness:.4f}")
+            total_terms = f"{box_fitness:.4f} (box) + {mask_fitness:.4f} (mask)"
+            if len(fitness_weight) == 10:
+                total_terms += f" + {boundary_fitness:.4f} (boundary)"
+            log_parts.append(f"  {total_terms} = {self.fitness:.4f}")
 
         else:
             # Standard task (detect, pose with 4 weights, segment with 4 weights, obb, classify)

--- a/ultralytics/models/yolo/segment/val.py
+++ b/ultralytics/models/yolo/segment/val.py
@@ -12,7 +12,7 @@ import torch.nn.functional as F
 from ultralytics.models.yolo.detect import DetectionValidator
 from ultralytics.utils import LOGGER, ops
 from ultralytics.utils.checks import check_requirements
-from ultralytics.utils.metrics import SegmentMetrics, mask_iou
+from ultralytics.utils.metrics import SegmentMetrics, mask_biou, mask_dice, mask_iou
 
 
 class SegmentationValidator(DetectionValidator):
@@ -50,17 +50,22 @@ class SegmentationValidator(DetectionValidator):
 
         # Validate fitness_weight length for segment task
         fitness_weight = getattr(self.args, "fitness_weight", None)
-        if fitness_weight is not None and len(fitness_weight) not in [4, 8]:
+        if fitness_weight is not None and len(fitness_weight) not in [4, 8, 10]:
             LOGGER.warning(
-                f"fitness_weight must have 4 or 8 values for segment task, got {len(fitness_weight)}. "
-                f"Using default weights. Expected: [P, R, mAP@0.5, mAP@0.5:0.95] (4 values) or "
-                f"[box_P, box_R, box_mAP@0.5, box_mAP@0.5:0.95, mask_P, mask_R, mask_mAP@0.5, mask_mAP@0.5:0.95] (8 values)."
+                f"fitness_weight must have 4, 8 or 10 values for segment task, got {len(fitness_weight)}. "
+                f"Using default weights. Expected: [P, R, mAP@0.5, mAP@0.5:0.95] (4 values), "
+                f"[box_P, box_R, box_mAP@0.5, box_mAP@0.5:0.95, mask_P, mask_R, mask_mAP@0.5, mask_mAP@0.5:0.95] (8 values), "
+                f"or the 8-value layout plus [mask_Dice, mask_BIoU] for boundary-aware fitness (10 values)."
             )
             fitness_weight = None
+
+        # Reuse the boundary kernel from the loss config so val/train agree on rim thickness.
+        boundary_kernel = int(getattr(self.args, "seg_boundary_kernel", 3) or 3)
 
         self.metrics = SegmentMetrics(
             fitness_weight=fitness_weight,
             class_weights=getattr(self.args, "class_weights_resolved", None),
+            boundary_kernel=boundary_kernel,
         )
 
     def preprocess(self, batch: dict[str, Any]) -> dict[str, Any]:
@@ -90,7 +95,7 @@ class SegmentationValidator(DetectionValidator):
 
     def get_desc(self) -> str:
         """Return a formatted description of evaluation metrics."""
-        return ("%22s" + "%11s" * 10) % (
+        return ("%22s" + "%11s" * 12) % (
             "Class",
             "Images",
             "Instances",
@@ -101,7 +106,9 @@ class SegmentationValidator(DetectionValidator):
             "Mask(P",
             "R",
             "mAP50",
-            "mAP50-95)",
+            "mAP50-95",
+            "Dice",
+            "BIoU)",
         )
 
     def postprocess(self, preds: list[torch.Tensor]) -> list[dict[str, torch.Tensor]]:
@@ -163,7 +170,9 @@ class SegmentationValidator(DetectionValidator):
             batch (dict[str, Any]): Dictionary containing batch data with keys like 'cls' and 'masks'.
 
         Returns:
-            (dict[str, np.ndarray]): A dictionary containing correct prediction matrices including 'tp_m' for mask IoU.
+            (dict[str, np.ndarray]): A dictionary containing correct prediction matrices including 'tp_m' for mask IoU,
+                and per matched-pair scalar arrays `mask_dice`, `mask_biou`, `matched_cls` consumed by
+                :class:`SegmentMetrics` for Dice / Boundary-IoU reporting.
 
         Examples:
             >>> preds = {"cls": torch.tensor([1, 0]), "masks": torch.rand(2, 640, 640), "bboxes": torch.rand(2, 4)}
@@ -173,16 +182,89 @@ class SegmentationValidator(DetectionValidator):
         Notes:
             - If `masks` is True, the function computes IoU between predicted and ground truth masks.
             - If `overlap` is True and `masks` is True, overlapping masks are taken into account when computing IoU.
+            - Dice / Boundary-IoU are recorded for pairs matched at IoU >= 0.5 with class agreement, mirroring the
+              greedy matching used by :py:meth:`BaseValidator.match_predictions`.
         """
         tp = super()._process_batch(preds, batch)
         gt_cls = batch["cls"]
+        empty_scores = np.zeros(0, dtype=np.float32)
+        empty_cls = np.zeros(0, dtype=np.int64)
         if gt_cls.shape[0] == 0 or preds["cls"].shape[0] == 0:
             tp_m = np.zeros((preds["cls"].shape[0], self.niou), dtype=bool)
+            dice_scores, biou_scores, matched_cls = empty_scores, empty_scores, empty_cls
         else:
-            iou = mask_iou(batch["masks"].flatten(1), preds["masks"].flatten(1).float())  # float, uint8
+            gt_masks = batch["masks"]
+            pred_masks = preds["masks"].float()
+            iou = mask_iou(gt_masks.flatten(1), pred_masks.flatten(1))  # (M, N)
             tp_m = self.match_predictions(preds["cls"], gt_cls, iou).cpu().numpy()
-        tp.update({"tp_m": tp_m})  # update tp with mask IoU
+            dice_scores, biou_scores, matched_cls = self._matched_mask_quality(
+                gt_masks, pred_masks, gt_cls, preds["cls"], iou
+            )
+        tp.update(
+            {
+                "tp_m": tp_m,
+                "mask_dice": dice_scores,
+                "mask_biou": biou_scores,
+                "matched_cls": matched_cls,
+            }
+        )
         return tp
+
+    def _matched_mask_quality(
+        self,
+        gt_masks: torch.Tensor,
+        pred_masks: torch.Tensor,
+        gt_cls: torch.Tensor,
+        pred_cls: torch.Tensor,
+        iou: torch.Tensor,
+        iou_threshold: float = 0.5,
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Greedy-match predictions to GT at `iou_threshold` (with class agreement) and score each pair.
+
+        Mirrors the non-scipy branch of :py:meth:`BaseValidator.match_predictions` but returns the actual
+        (gt_idx, pred_idx) pairs so we can compute scalar Dice / Boundary-IoU per matched instance.
+
+        Args:
+            gt_masks (torch.Tensor): GT binary masks (M, H, W).
+            pred_masks (torch.Tensor): Predicted binary masks (N, H, W).
+            gt_cls (torch.Tensor): GT class indices (M,).
+            pred_cls (torch.Tensor): Predicted class indices (N,).
+            iou (torch.Tensor): Pairwise mask IoU (M, N).
+            iou_threshold (float, optional): Matching threshold.
+
+        Returns:
+            (tuple[np.ndarray, np.ndarray, np.ndarray]): (dice_scores, biou_scores, matched_cls), each of shape (K,)
+            where K is the number of matched pairs. Empty arrays when no matches.
+        """
+        # Mask out cross-class candidates (class agreement, like match_predictions).
+        correct_class = gt_cls[:, None] == pred_cls  # (M, N)
+        iou_masked = (iou * correct_class).cpu().numpy()
+
+        matches = np.nonzero(iou_masked >= iou_threshold)
+        matches = np.array(matches).T  # (K, 2): columns are (gt_idx, pred_idx)
+        if not matches.shape[0]:
+            empty_scores = np.zeros(0, dtype=np.float32)
+            return empty_scores, empty_scores, np.zeros(0, dtype=np.int64)
+
+        if matches.shape[0] > 1:
+            # Standard greedy reduction: keep highest-IoU per GT and per pred (same order as match_predictions).
+            order = iou_masked[matches[:, 0], matches[:, 1]].argsort()[::-1]
+            matches = matches[order]
+            matches = matches[np.unique(matches[:, 1], return_index=True)[1]]
+            matches = matches[np.unique(matches[:, 0], return_index=True)[1]]
+
+        gi = matches[:, 0].astype(np.int64)
+        pi = matches[:, 1].astype(np.int64)
+        gt_sel = gt_masks[gi]  # (K, H, W)
+        pred_sel = pred_masks[pi]  # (K, H, W), float in {0,1}
+
+        # Pairwise (K, K) wastes work for large K — compute only the K matched scalars via the diagonal.
+        dice_mat = mask_dice(gt_sel.flatten(1), pred_sel.flatten(1))
+        biou_mat = mask_biou(gt_sel, pred_sel, self.metrics.boundary_kernel)
+        dice_scores = dice_mat.diagonal().detach().cpu().numpy().astype(np.float32)
+        biou_scores = biou_mat.diagonal().detach().cpu().numpy().astype(np.float32)
+        matched_cls = gt_cls[gi].detach().cpu().numpy().astype(np.int64)
+        return dice_scores, biou_scores, matched_cls
 
     def plot_predictions(self, batch: dict[str, Any], preds: list[dict[str, torch.Tensor]], ni: int) -> None:
         """Plot batch predictions with masks and bounding boxes.

--- a/ultralytics/models/yolo/segment/val.py
+++ b/ultralytics/models/yolo/segment/val.py
@@ -234,7 +234,7 @@ class SegmentationValidator(DetectionValidator):
 
         Returns:
             (tuple[np.ndarray, np.ndarray, np.ndarray]): (dice_scores, biou_scores, matched_cls), each of shape (K,)
-            where K is the number of matched pairs. Empty arrays when no matches.
+                where K is the number of matched pairs. Empty arrays when no matches.
         """
         # Mask out cross-class candidates (class agreement, like match_predictions).
         correct_class = gt_cls[:, None] == pred_cls  # (M, N)

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -163,9 +163,9 @@ def mask_iou(mask1: torch.Tensor, mask2: torch.Tensor, eps: float = 1e-7) -> tor
 def mask_dice(mask1: torch.Tensor, mask2: torch.Tensor, eps: float = 1e-7) -> torch.Tensor:
     """Calculate pairwise Dice (F1) coefficient between two sets of binary masks.
 
-    Dice = 2 * |A ∩ B| / (|A| + |B|). Equivalent to F1 on per-pixel labels and monotonic with IoU
-    (Dice = 2*IoU / (1 + IoU)) but more lenient on small misalignments — useful as a complementary
-    overlap metric for instance segmentation evaluation.
+    Dice = 2 * |A ∩ B| / (|A| + |B|). Equivalent to F1 on per-pixel labels and monotonic with IoU (Dice = 2*IoU / (1 +
+    IoU)) but more lenient on small misalignments — useful as a complementary overlap metric for instance segmentation
+    evaluation.
 
     Args:
         mask1 (torch.Tensor): Ground-truth binary masks of shape (N, H*W) (flattened).
@@ -183,8 +183,8 @@ def mask_dice(mask1: torch.Tensor, mask2: torch.Tensor, eps: float = 1e-7) -> to
 def mask_boundary_rim(mask: torch.Tensor, kernel: int) -> torch.Tensor:
     """Extract the paper-style boundary rim of binary masks via mask - erode(mask, k).
 
-    Computes the inside-k rim used by the Boundary-IoU definition of Cheng et al. 2021. Performed
-    on the GPU when the input lives there, no autograd is needed (operates on GT/binarized preds).
+    Computes the inside-k rim used by the Boundary-IoU definition of Cheng et al. 2021. Performed on the GPU when the
+    input lives there, no autograd is needed (operates on GT/binarized preds).
 
     Args:
         mask (torch.Tensor): Binary masks of shape (N, H, W) with values in {0, 1}.
@@ -202,9 +202,8 @@ def mask_boundary_rim(mask: torch.Tensor, kernel: int) -> torch.Tensor:
 def mask_biou(mask1: torch.Tensor, mask2: torch.Tensor, kernel: int = 3, eps: float = 1e-7) -> torch.Tensor:
     """Calculate paper-style Boundary IoU between two sets of binary masks (Cheng et al. 2021).
 
-    Each mask is reduced to its inside-`kernel` rim (`mask - erode(mask, kernel)`), then IoU is
-    computed between rims. This focuses the score on contour accuracy and is far more sensitive to
-    boundary errors than standard mask IoU.
+    Each mask is reduced to its inside-`kernel` rim (`mask - erode(mask, kernel)`), then IoU is computed between rims.
+    This focuses the score on contour accuracy and is far more sensitive to boundary errors than standard mask IoU.
 
     Args:
         mask1 (torch.Tensor): Ground-truth binary masks of shape (N, H, W).
@@ -1322,8 +1321,8 @@ class SegmentMetrics(DetMetrics):
                 - 10 values: 8-value layout plus [mask_Dice, mask_BIoU]; only valid for segment task and
                   lets boundary-quality scores influence best-checkpoint selection.
             class_weights (list, optional): Per-class importance weights for weighted mean metrics in fitness.
-            boundary_kernel (int, optional): Odd kernel size (>=3) for paper-style Boundary IoU; should
-                match `seg_boundary_kernel` used by the loss so train/val agree on rim thickness.
+            boundary_kernel (int, optional): Odd kernel size (>=3) for paper-style Boundary IoU; should match
+                `seg_boundary_kernel` used by the loss so train/val agree on rim thickness.
         """
         self.dice_fitness_weight = 0.0
         self.biou_fitness_weight = 0.0

--- a/ultralytics/utils/metrics.py
+++ b/ultralytics/utils/metrics.py
@@ -11,6 +11,7 @@ from typing import Any
 
 import numpy as np
 import torch
+import torch.nn.functional as F
 
 from ultralytics.utils import LOGGER, DataExportMixin, SimpleClass, TryExcept, checks, plt_settings
 
@@ -156,6 +157,68 @@ def mask_iou(mask1: torch.Tensor, mask2: torch.Tensor, eps: float = 1e-7) -> tor
     """
     intersection = torch.matmul(mask1, mask2.T).clamp_(0)
     union = (mask1.sum(1)[:, None] + mask2.sum(1)[None]) - intersection  # (area1 + area2) - intersection
+    return intersection / (union + eps)
+
+
+def mask_dice(mask1: torch.Tensor, mask2: torch.Tensor, eps: float = 1e-7) -> torch.Tensor:
+    """Calculate pairwise Dice (F1) coefficient between two sets of binary masks.
+
+    Dice = 2 * |A ∩ B| / (|A| + |B|). Equivalent to F1 on per-pixel labels and monotonic with IoU
+    (Dice = 2*IoU / (1 + IoU)) but more lenient on small misalignments — useful as a complementary
+    overlap metric for instance segmentation evaluation.
+
+    Args:
+        mask1 (torch.Tensor): Ground-truth binary masks of shape (N, H*W) (flattened).
+        mask2 (torch.Tensor): Predicted binary masks of shape (M, H*W) (flattened).
+        eps (float, optional): Small constant to avoid division by zero.
+
+    Returns:
+        (torch.Tensor): Pairwise Dice of shape (N, M).
+    """
+    intersection = torch.matmul(mask1, mask2.T).clamp_(0)
+    denom = mask1.sum(1)[:, None] + mask2.sum(1)[None]
+    return (2.0 * intersection) / (denom + eps)
+
+
+def mask_boundary_rim(mask: torch.Tensor, kernel: int) -> torch.Tensor:
+    """Extract the paper-style boundary rim of binary masks via mask - erode(mask, k).
+
+    Computes the inside-k rim used by the Boundary-IoU definition of Cheng et al. 2021. Performed
+    on the GPU when the input lives there, no autograd is needed (operates on GT/binarized preds).
+
+    Args:
+        mask (torch.Tensor): Binary masks of shape (N, H, W) with values in {0, 1}.
+        kernel (int): Odd integer >= 3 controlling rim thickness in pixels.
+
+    Returns:
+        (torch.Tensor): Boundary rims of shape (N, H, W), values in {0, 1}.
+    """
+    g = mask.unsqueeze(1).float()
+    pad = kernel // 2
+    eroded = -F.max_pool2d(-g, kernel, stride=1, padding=pad)
+    return (g - eroded).clamp_(0).squeeze(1)
+
+
+def mask_biou(mask1: torch.Tensor, mask2: torch.Tensor, kernel: int = 3, eps: float = 1e-7) -> torch.Tensor:
+    """Calculate paper-style Boundary IoU between two sets of binary masks (Cheng et al. 2021).
+
+    Each mask is reduced to its inside-`kernel` rim (`mask - erode(mask, kernel)`), then IoU is
+    computed between rims. This focuses the score on contour accuracy and is far more sensitive to
+    boundary errors than standard mask IoU.
+
+    Args:
+        mask1 (torch.Tensor): Ground-truth binary masks of shape (N, H, W).
+        mask2 (torch.Tensor): Predicted binary masks of shape (M, H, W).
+        kernel (int, optional): Odd integer >= 3 for rim thickness; should match `seg_boundary_kernel`.
+        eps (float, optional): Small constant to avoid division by zero.
+
+    Returns:
+        (torch.Tensor): Pairwise Boundary-IoU of shape (N, M).
+    """
+    rim1 = mask_boundary_rim(mask1, kernel).flatten(1)  # (N, H*W)
+    rim2 = mask_boundary_rim(mask2, kernel).flatten(1)  # (M, H*W)
+    intersection = torch.matmul(rim1, rim2.T).clamp_(0)
+    union = (rim1.sum(1)[:, None] + rim2.sum(1)[None]) - intersection
     return intersection / (union + eps)
 
 
@@ -878,9 +941,10 @@ class Metric(SimpleClass):
         self.all_ap = []  # (nc, 10)
         self.ap_class_index = []  # (nc, )
         self.nc = 0
-        # Handle fitness_weight: if 8 values provided, use only first 4 for detection metrics
-        if fitness_weight and len(fitness_weight) == 8:
-            self.fitness_weight = fitness_weight[:4]  # use first 4 for box detection
+        # Handle fitness_weight: only the first 4 entries describe box/mask detection metrics.
+        # Accept legacy 8-value (segment/pose) and new 10-value (segment with Dice/BIoU) layouts.
+        if fitness_weight and len(fitness_weight) in (8, 10):
+            self.fitness_weight = fitness_weight[:4]
         else:
             self.fitness_weight = fitness_weight or [0.0, 0.9, 0.1, 0.0]  # default weights for SkillReal dataset
         # Per-class weights for weighted mean metrics (None = standard unweighted mean)
@@ -1241,7 +1305,11 @@ class SegmentMetrics(DetMetrics):
     """
 
     def __init__(
-        self, names: dict[int, str] = {}, fitness_weight: list | None = None, class_weights: list | None = None
+        self,
+        names: dict[int, str] = {},
+        fitness_weight: list | None = None,
+        class_weights: list | None = None,
+        boundary_kernel: int = 3,
     ) -> None:
         """Initialize a SegmentMetrics instance with a save directory, plot flag, and class names.
 
@@ -1251,26 +1319,43 @@ class SegmentMetrics(DetMetrics):
                 - 4 values [P, R, mAP@0.5, mAP@0.5:0.95]: same weights used for both box and mask (backward compatible)
                 - 8 values [box_P, box_R, box_mAP@0.5, box_mAP@0.5:0.95, mask_P, mask_R, mask_mAP@0.5, mask_mAP@0.5:0.95]:
                   separate weights for box and mask metrics
+                - 10 values: 8-value layout plus [mask_Dice, mask_BIoU]; only valid for segment task and
+                  lets boundary-quality scores influence best-checkpoint selection.
             class_weights (list, optional): Per-class importance weights for weighted mean metrics in fitness.
+            boundary_kernel (int, optional): Odd kernel size (>=3) for paper-style Boundary IoU; should
+                match `seg_boundary_kernel` used by the loss so train/val agree on rim thickness.
         """
-        # Split fitness weights for box and mask metrics
-        if fitness_weight and len(fitness_weight) == 8:
-            # New format: separate weights for box and mask
+        self.dice_fitness_weight = 0.0
+        self.biou_fitness_weight = 0.0
+        if fitness_weight and len(fitness_weight) == 10:
+            box_weights = fitness_weight[:4]
+            mask_weights = fitness_weight[4:8]
+            self.dice_fitness_weight = float(fitness_weight[8])
+            self.biou_fitness_weight = float(fitness_weight[9])
+        elif fitness_weight and len(fitness_weight) == 8:
             box_weights = fitness_weight[:4]
             mask_weights = fitness_weight[4:]
         elif fitness_weight and len(fitness_weight) == 4:
-            # Backward compatibility: use same weights for both
             box_weights = fitness_weight
             mask_weights = fitness_weight
         else:
-            # Default or None
             box_weights = fitness_weight
             mask_weights = fitness_weight
 
         DetMetrics.__init__(self, names, box_weights, class_weights=class_weights)
         self.seg = Metric(fitness_weight=mask_weights, class_weights=class_weights)
         self.task = "segment"
+        self.boundary_kernel = max(3, int(boundary_kernel) | 1)  # force odd, >=3
         self.stats["tp_m"] = []  # add additional stats for masks
+        # Boundary-quality stats: per matched (GT, pred) pair scalar Dice / BIoU and the class index
+        self.stats["mask_dice"] = []
+        self.stats["mask_biou"] = []
+        self.stats["matched_cls"] = []
+        # Per-class aggregates populated in process(); aligned with self.seg.ap_class_index when set.
+        self.dice_per_class = np.zeros(0)
+        self.biou_per_class = np.zeros(0)
+        self.dice_mean = 0.0
+        self.biou_mean = 0.0
 
     def process(self, save_dir: Path = Path("."), plot: bool = False, on_plot=None) -> dict[str, np.ndarray]:
         """Process the detection and segmentation metrics over the given set of predictions.
@@ -1297,6 +1382,41 @@ class SegmentMetrics(DetMetrics):
         )[2:]
         self.seg.nc = len(self.names)
         self.seg.update(results_mask)
+
+        # Aggregate per-matched-pair Dice / BIoU into per-class arrays + overall means.
+        # `mask_dice`, `mask_biou`, `matched_cls` come from SegmentationValidator._process_batch.
+        nc = len(self.names)
+        self.dice_per_class = np.zeros(nc, dtype=np.float64)
+        self.biou_per_class = np.zeros(nc, dtype=np.float64)
+        self.dice_mean = 0.0
+        self.biou_mean = 0.0
+        dice_all = stats.get("mask_dice", np.zeros(0, dtype=np.float64))
+        biou_all = stats.get("mask_biou", np.zeros(0, dtype=np.float64))
+        matched_cls_all = stats.get("matched_cls", np.zeros(0, dtype=np.int64))
+        if len(dice_all):
+            per_class_counts = np.bincount(matched_cls_all.astype(int), minlength=nc)
+            for c in np.unique(matched_cls_all.astype(int)):
+                m = matched_cls_all == c
+                self.dice_per_class[c] = dice_all[m].mean()
+                self.biou_per_class[c] = biou_all[m].mean()
+            # Use the same aggregation strategy as Metric.mean_results: optional class_weights, restricted to
+            # classes that produced detections (ap_class_index) so a class with no matches doesn't drag mean to 0.
+            detected = np.asarray(self.seg.ap_class_index, dtype=int) if len(self.seg.ap_class_index) else None
+            if detected is not None and detected.size:
+                d_vals = self.dice_per_class[detected]
+                b_vals = self.biou_per_class[detected]
+                # Only average over detected classes that actually had matched pairs (per_class_counts > 0).
+                have = per_class_counts[detected] > 0
+                d_sel, b_sel = d_vals[have], b_vals[have]
+                if d_sel.size:
+                    cw = self.seg._get_detected_class_weights()
+                    if cw is not None:
+                        cw_sel = cw[have]
+                        self.dice_mean = float(np.average(d_sel, weights=cw_sel))
+                        self.biou_mean = float(np.average(b_sel, weights=cw_sel))
+                    else:
+                        self.dice_mean = float(d_sel.mean())
+                        self.biou_mean = float(b_sel.mean())
         return stats
 
     @property
@@ -1308,15 +1428,20 @@ class SegmentMetrics(DetMetrics):
             "metrics/recall(M)",
             "metrics/mAP50(M)",
             "metrics/mAP50-95(M)",
+            "metrics/dice(M)",
+            "metrics/biou(M)",
         ]
 
     def mean_results(self) -> list[float]:
         """Return the mean metrics for bounding box and segmentation results."""
-        return DetMetrics.mean_results(self) + self.seg.mean_results()
+        return DetMetrics.mean_results(self) + self.seg.mean_results() + [self.dice_mean, self.biou_mean]
 
     def class_result(self, i: int) -> list[float]:
         """Return classification results for a specified class index."""
-        return DetMetrics.class_result(self, i) + self.seg.class_result(i)
+        c = int(self.seg.ap_class_index[i]) if i < len(self.seg.ap_class_index) else 0
+        dice_i = float(self.dice_per_class[c]) if c < len(self.dice_per_class) else 0.0
+        biou_i = float(self.biou_per_class[c]) if c < len(self.biou_per_class) else 0.0
+        return DetMetrics.class_result(self, i) + self.seg.class_result(i) + (dice_i, biou_i)
 
     @property
     def maps(self) -> np.ndarray:
@@ -1325,8 +1450,13 @@ class SegmentMetrics(DetMetrics):
 
     @property
     def fitness(self) -> float:
-        """Return the fitness score for both segmentation and bounding box models."""
-        return self.seg.fitness() + DetMetrics.fitness.fget(self)
+        """Return the fitness score for both segmentation and bounding box models.
+
+        When fitness_weight has 10 entries, the last two elements weight mean Dice and mean BIoU
+        (segment task only) so boundary quality can drive best-checkpoint selection.
+        """
+        base = self.seg.fitness() + DetMetrics.fitness.fget(self)
+        return base + self.dice_fitness_weight * self.dice_mean + self.biou_fitness_weight * self.biou_mean
 
     @property
     def curves(self) -> list[str]:
@@ -1370,6 +1500,11 @@ class SegmentMetrics(DetMetrics):
         summary = DetMetrics.summary(self, normalize, decimals)  # get box summary
         for i, s in enumerate(summary):
             s.update({**{k: round(v[i], decimals) for k, v in per_class.items()}})
+            # Per-class Dice / BIoU live in arrays indexed by absolute class id (not ap_class_index order).
+            c = int(self.seg.ap_class_index[i]) if i < len(self.seg.ap_class_index) else 0
+            if c < len(self.dice_per_class):
+                s["Mask-Dice"] = round(float(self.dice_per_class[c]), decimals)
+                s["Mask-BIoU"] = round(float(self.biou_per_class[c]), decimals)
         return summary
 
 


### PR DESCRIPTION

  Jira: SKLRDEV-3558

  What

  Adds per-class Dice and Boundary IoU (BIoU) scores to segmentation validation. BIoU focuses on contour accuracy by
   computing IoU between mask boundary rims rather than full masks (Cheng et al. 2021).

  Changes

  - metrics.py — mask_dice, mask_boundary_rim, mask_biou helpers; SegmentMetrics widened to report and aggregate
  both metrics
  - val.py — _matched_mask_quality scores each greedy-matched (GT, pred) pair; Dice/BIoU columns added to validation
   output
  - trainer.py — fitness logging extended for the new 10-value weight layout
  - default.yaml — documents the optional [box×4, mask×4, Dice_w, BIoU_w] fitness_weight format
  - tests/test_boundary_metrics.py — 17 unit tests (helpers, SegmentMetrics integration, end-to-end validator)

  Notes

  - Fully backward-compatible: existing 4- and 8-value fitness_weight configs unchanged
  - boundary_kernel defaults to 3; can be aligned with seg_boundary_kernel from loss config

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Dice and Boundary-IoU metrics to evaluate mask quality in segmentation tasks
  * Extended segment training to support optional boundary metric weighting in fitness calculations

* **Tests**
  * Added comprehensive test suite for boundary metrics validation and integration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SkillReal-LTD/ultralytics/pull/19?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->