### PR TITLE
ci: trigger algo-ai-training rebuild on main push (workflow_dispatch)

### DIFF
--- a/.github/workflows/trigger_training_rebuild.yaml
+++ b/.github/workflows/trigger_training_rebuild.yaml
@@ -1,0 +1,25 @@
+name: Trigger training image rebuild
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  dispatch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send repository_dispatch to algo-ai-training
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.TRAINING_REPO_DISPATCH_TOKEN }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: 'SkillReal-LTD',
+              repo: 'algo-ai-training',
+              event_type: 'ultralytics-updated',
+              client_payload: {
+                ultralytics_sha: context.sha,
+                ultralytics_ref: context.ref
+              }
+            });


### PR DESCRIPTION
## Summary
- On push to `main`, calls the GitHub `workflow_dispatch` API to trigger `ecr_training.yaml` on `SkillReal-LTD/algo-ai-training@dev`
- This rebuilds the sagemaker training Docker image so it picks up the latest commits of this fork (the Dockerfile installs from `@main`)

## Why workflow_dispatch (not repository_dispatch)
`repository_dispatch` only fires on the default branch (`main`) of the target repo. The algo-ai-training team uses `dev` as the integration branch, so `workflow_dispatch` is required — it accepts an arbitrary `ref`.

## Pre-requisite
- Add a secret `TRAINING_REPO_DISPATCH_TOKEN` to this repo (fine-grained PAT with **Actions: Read and write** on `algo-ai-training`)

## Related
- SkillReal-LTD/algo-ai-training#289 (companion PR adding `workflow_dispatch` to `ecr_training.yaml`)

## Test plan
- [ ] Confirm `TRAINING_REPO_DISPATCH_TOKEN` secret is configured
- [ ] Merge SkillReal-LTD/algo-ai-training#289 first
- [ ] Push a test commit to `main` and verify the `ecr_training` workflow fires in `algo-ai-training`