### PR TITLE
fix(ci): use workflow_dispatch to target algo-ai-training@dev

### DIFF
--- a/.github/workflows/trigger_training_rebuild.yaml
+++ b/.github/workflows/trigger_training_rebuild.yaml
@@ -9,17 +9,14 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-      - name: Send repository_dispatch to algo-ai-training
+      - name: Trigger ecr_training workflow on algo-ai-training@dev
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.TRAINING_REPO_DISPATCH_TOKEN }}
           script: |
-            await github.rest.repos.createDispatchEvent({
+            await github.rest.actions.createWorkflowDispatch({
               owner: 'SkillReal-LTD',
               repo: 'algo-ai-training',
-              event_type: 'ultralytics-updated',
-              client_payload: {
-                ultralytics_sha: context.sha,
-                ultralytics_ref: context.ref
-              }
+              workflow_id: 'ecr_training.yaml',
+              ref: 'dev',
             });


### PR DESCRIPTION
## Summary
Fixes the trigger workflow merged in #20 — switches from `repository_dispatch` to `workflow_dispatch`.

## Why
`repository_dispatch` only fires on the **default branch** of the target repo. Since `algo-ai-training` doesn't use `main` as its integration branch (`dev` is used instead), the dispatch event has no listener and the rebuild never fires.

`workflow_dispatch` lets us target a specific `ref`, so we can point at `dev` directly.

## Related
- SkillReal-LTD/algo-ai-training#289 — companion PR adding the `workflow_dispatch` trigger to `ecr_training.yaml`

## Test plan
- [ ] Merge SkillReal-LTD/algo-ai-training#289 first
- [ ] Confirm `TRAINING_REPO_DISPATCH_TOKEN` secret is configured
- [ ] After merging this, push a commit to `main` and verify the `ecr_training` workflow fires on `algo-ai-training@dev`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the automated training rebuild workflow trigger to use an improved invocation method for better workflow orchestration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/SkillReal-LTD/ultralytics/pull/21?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->