### PR TITLE
chore(ci): point rebuild dispatch at renamed algo-ai-training workflow

### DIFF
--- a/.github/workflows/trigger_training_rebuild.yaml
+++ b/.github/workflows/trigger_training_rebuild.yaml
@@ -9,14 +9,17 @@ jobs:
   dispatch:
     runs-on: ubuntu-latest
     steps:
-      - name: Trigger ecr_training workflow on algo-ai-training@dev
+      - name: Trigger build_training_image workflow on algo-ai-training@dev
         uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.TRAINING_REPO_DISPATCH_TOKEN }}
           script: |
+            // workflow_id is the filename: renamed from ecr_training.yaml when that
+            // workflow gained Artifact Registry delivery alongside ECR. A stale name
+            // here fails as a silent 404.
             await github.rest.actions.createWorkflowDispatch({
               owner: 'SkillReal-LTD',
               repo: 'algo-ai-training',
-              workflow_id: 'ecr_training.yaml',
+              workflow_id: 'build_training_image.yaml',
               ref: 'dev',
             });


### PR DESCRIPTION
## Why

`algo-ai-training` renamed `ecr_training.yaml` → `build_training_image.yaml`, because that workflow now delivers the training image to Google Artifact Registry as well as ECR and the `ecr_` prefix no longer described it.

`createWorkflowDispatch` addresses a workflow **by filename**. Left unchanged, this call returns 404 and the rebuild trigger silently stops firing — nothing here would go red, the training image would just quietly stop rebuilding when this repo's `main` moves.

## What

One-line change to `workflow_id`, plus the step name and a comment recording why the filename matters.

## Merge order

Merge **after** the `algo-ai-training` PR that performs the rename. Between the two merges this dispatch 404s; merging this one first would break it immediately instead.

- `skillreal-infra`: https://github.com/SkillReal-LTD/skillreal-infra/pull/6 (WIF identity the new workflow pushes with)

## Verification

`actionlint` clean. The dispatch itself can only be exercised once both sides are merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the training rebuild trigger to use the renamed workflow, preventing dispatch failures caused by outdated workflow references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->